### PR TITLE
remove secret key options for stripe triggers

### DIFF
--- a/ts/src/apps/stripe/index.ts
+++ b/ts/src/apps/stripe/index.ts
@@ -67,7 +67,7 @@ export default (locale: Locales) =>
       url: 'https://api.stripe.com',
       data: 'json',
       oauth2_grant_type: 'authorization_code',
-      oauth2_client_id: '1208416840087775',
+      oauth2_client_id: 'ca_RBbHjT1Rfnd1id8ccxMtAvq1N0VnXtmu',
       oauth2_client_secret: actionsCatalogue.getOauth2ClientSecret(STRIPE_APP_NAME),
       oauth2_auth_url: 'https://marketplace.stripe.com/oauth/v2/authorize',
       oauth2_token_url: 'https://api.stripe.com/v1/oauth/token',

--- a/ts/src/apps/stripe/triggers/charge-dispute-created.trigger.ts
+++ b/ts/src/apps/stripe/triggers/charge-dispute-created.trigger.ts
@@ -13,13 +13,6 @@ export default {
   action: 'charge_dispute_created',
   action_code: EQoreAppActionCode.EVENT,
   webhook_method: 'POST',
-  options: {
-    secretKey: {
-      required: true,
-      type: 'string',
-      sensitive: true,
-    },
-  },
   webhook_register: createRegisterStripeWebhookFunction(triggerEvents),
   webhook_deregister: deregisterStripeWebhook,
   get_example_event_data: createGetStripeExampleEventDataFunction(triggerEvents),

--- a/ts/src/apps/stripe/triggers/charge-refunded.trigger.ts
+++ b/ts/src/apps/stripe/triggers/charge-refunded.trigger.ts
@@ -13,13 +13,6 @@ export default {
   action: 'charge_refunded',
   action_code: EQoreAppActionCode.EVENT,
   webhook_method: 'POST',
-  options: {
-    secretKey: {
-      required: true,
-      type: 'string',
-      sensitive: true,
-    },
-  },
   webhook_register: createRegisterStripeWebhookFunction(triggerEvents),
   webhook_deregister: deregisterStripeWebhook,
   get_example_event_data: createGetStripeExampleEventDataFunction(triggerEvents),

--- a/ts/src/apps/stripe/triggers/charge-succeeded.trigger.ts
+++ b/ts/src/apps/stripe/triggers/charge-succeeded.trigger.ts
@@ -13,13 +13,6 @@ export default {
   action: 'charge_succeeded',
   action_code: EQoreAppActionCode.EVENT,
   webhook_method: 'POST',
-  options: {
-    secretKey: {
-      required: true,
-      type: 'string',
-      sensitive: true,
-    },
-  },
   webhook_register: createRegisterStripeWebhookFunction(triggerEvents),
   webhook_deregister: deregisterStripeWebhook,
   get_example_event_data: createGetStripeExampleEventDataFunction(triggerEvents),

--- a/ts/src/apps/stripe/triggers/checkout-session-completed.trigger.ts
+++ b/ts/src/apps/stripe/triggers/checkout-session-completed.trigger.ts
@@ -12,13 +12,6 @@ export default {
   action: 'checkout_session_completed',
   action_code: EQoreAppActionCode.EVENT,
   webhook_method: 'POST',
-  options: {
-    secretKey: {
-      required: true,
-      type: 'string',
-      sensitive: true,
-    },
-  },
   webhook_register: createRegisterStripeWebhookFunction(triggerEvents),
   webhook_deregister: deregisterStripeWebhook,
   get_example_event_data: createGetStripeExampleEventDataFunction(triggerEvents),

--- a/ts/src/apps/stripe/triggers/customer-created.trigger.ts
+++ b/ts/src/apps/stripe/triggers/customer-created.trigger.ts
@@ -12,13 +12,6 @@ export default {
   action: 'customer_created',
   action_code: EQoreAppActionCode.EVENT,
   webhook_method: 'POST',
-  options: {
-    secretKey: {
-      required: true,
-      type: 'string',
-      sensitive: true,
-    },
-  },
   webhook_register: createRegisterStripeWebhookFunction(triggerEvents),
   webhook_deregister: deregisterStripeWebhook,
   get_example_event_data: createGetStripeExampleEventDataFunction(triggerEvents),

--- a/ts/src/apps/stripe/triggers/helpers.ts
+++ b/ts/src/apps/stripe/triggers/helpers.ts
@@ -10,14 +10,14 @@ export const deregisterStripeWebhook: IQoreAppActionWithWebhookBase['webhook_der
   regInfo
 ) => {
   const {
-    opts: { secretKey },
+    conn_opts: { token },
   } = context;
   const { webhook } = regInfo;
 
   await QorusRequest.deleteReq<any>(
     {
       headers: {
-        Authorization: `Bearer ${secretKey}`,
+        Authorization: `Bearer ${token}`,
       },
       path: `/v1/webhook_endpoints/${webhook.id}`,
     },
@@ -33,7 +33,7 @@ export const createRegisterStripeWebhookFunction = (
 ): IQoreAppActionWithWebhookBase['webhook_register'] => {
   return async (context, url) => {
     const {
-      opts: { secretKey },
+      conn_opts: { token },
     } = context;
 
     try {
@@ -47,8 +47,11 @@ export const createRegisterStripeWebhookFunction = (
         'https://api.stripe.com/v1/webhook_endpoints',
         webhookData,
         {
+          params: {
+            api_version: '2024-12-18.acacia',
+          },
           headers: {
-            Authorization: `Bearer ${secretKey}`,
+            Authorization: `Bearer ${token}`,
             'Content-Type': 'application/x-www-form-urlencoded',
           },
         }
@@ -67,7 +70,7 @@ export const createGetStripeExampleEventDataFunction: (
 ) => IQoreAppActionWithWebhookBase['get_example_event_data'] = (eventTypes: TStripeEventType[]) => {
   return async (context) => {
     const {
-      opts: { secretKey },
+      conn_opts: { token },
     } = context;
 
     try {
@@ -78,7 +81,7 @@ export const createGetStripeExampleEventDataFunction: (
 
       const { data } = await axios.get('https://api.stripe.com/v1/events', {
         headers: {
-          Authorization: `Bearer ${secretKey}`,
+          Authorization: `Bearer ${token}`,
         },
         params,
       });

--- a/ts/src/apps/stripe/triggers/invoice-created.trigger.ts
+++ b/ts/src/apps/stripe/triggers/invoice-created.trigger.ts
@@ -13,13 +13,6 @@ export default {
   action: 'invoice_created',
   action_code: EQoreAppActionCode.EVENT,
   webhook_method: 'POST',
-  options: {
-    secretKey: {
-      required: true,
-      type: 'string',
-      sensitive: true,
-    },
-  },
   webhook_register: createRegisterStripeWebhookFunction(triggerEvents),
   webhook_deregister: deregisterStripeWebhook,
   get_example_event_data: createGetStripeExampleEventDataFunction(triggerEvents),

--- a/ts/src/apps/stripe/triggers/invoice-payment-failed.trigger.ts
+++ b/ts/src/apps/stripe/triggers/invoice-payment-failed.trigger.ts
@@ -12,13 +12,6 @@ export default {
   action: 'invoice_payment_failed',
   action_code: EQoreAppActionCode.EVENT,
   webhook_method: 'POST',
-  options: {
-    secretKey: {
-      required: true,
-      type: 'string',
-      sensitive: true,
-    },
-  },
   webhook_register: createRegisterStripeWebhookFunction(triggerEvents),
   webhook_deregister: deregisterStripeWebhook,
   get_example_event_data: createGetStripeExampleEventDataFunction(triggerEvents),

--- a/ts/src/apps/stripe/triggers/payment-intent-failed.trigger.ts
+++ b/ts/src/apps/stripe/triggers/payment-intent-failed.trigger.ts
@@ -13,13 +13,6 @@ export default {
   action: 'payment_intent_failed',
   action_code: EQoreAppActionCode.EVENT,
   webhook_method: 'POST',
-  options: {
-    secretKey: {
-      required: true,
-      type: 'string',
-      sensitive: true,
-    },
-  },
   webhook_register: createRegisterStripeWebhookFunction(triggerEvents),
   webhook_deregister: deregisterStripeWebhook,
   get_example_event_data: createGetStripeExampleEventDataFunction(triggerEvents),

--- a/ts/src/apps/stripe/triggers/payment-intent-succeeded.trigger.ts
+++ b/ts/src/apps/stripe/triggers/payment-intent-succeeded.trigger.ts
@@ -13,13 +13,6 @@ export default {
   action: 'payment_intent_succeeded',
   action_code: EQoreAppActionCode.EVENT,
   webhook_method: 'POST',
-  options: {
-    secretKey: {
-      required: true,
-      type: 'string',
-      sensitive: true,
-    },
-  },
   webhook_register: createRegisterStripeWebhookFunction(triggerEvents),
   webhook_deregister: deregisterStripeWebhook,
   get_example_event_data: createGetStripeExampleEventDataFunction(triggerEvents),

--- a/ts/src/apps/stripe/triggers/payment-link-created.trigger.ts
+++ b/ts/src/apps/stripe/triggers/payment-link-created.trigger.ts
@@ -12,13 +12,6 @@ export default {
   action: 'payment_link_created',
   action_code: EQoreAppActionCode.EVENT,
   webhook_method: 'POST',
-  options: {
-    secretKey: {
-      required: true,
-      type: 'string',
-      sensitive: true,
-    },
-  },
   webhook_register: createRegisterStripeWebhookFunction(triggerEvents),
   webhook_deregister: deregisterStripeWebhook,
   get_example_event_data: createGetStripeExampleEventDataFunction(triggerEvents),

--- a/ts/src/apps/stripe/triggers/subscription-canceled.trigger.ts
+++ b/ts/src/apps/stripe/triggers/subscription-canceled.trigger.ts
@@ -13,13 +13,6 @@ export default {
   action: 'subscription_canceled',
   action_code: EQoreAppActionCode.EVENT,
   webhook_method: 'POST',
-  options: {
-    secretKey: {
-      required: true,
-      type: 'string',
-      sensitive: true,
-    },
-  },
   webhook_register: createRegisterStripeWebhookFunction(triggerEvents),
   webhook_deregister: deregisterStripeWebhook,
   get_example_event_data: createGetStripeExampleEventDataFunction(triggerEvents),

--- a/ts/src/apps/stripe/triggers/subscription-created.trigger.ts
+++ b/ts/src/apps/stripe/triggers/subscription-created.trigger.ts
@@ -13,13 +13,6 @@ export default {
   action: 'subscription_created',
   action_code: EQoreAppActionCode.EVENT,
   webhook_method: 'POST',
-  options: {
-    secretKey: {
-      required: true,
-      type: 'string',
-      sensitive: true,
-    },
-  },
   webhook_register: createRegisterStripeWebhookFunction(triggerEvents),
   webhook_deregister: deregisterStripeWebhook,
   get_example_event_data: createGetStripeExampleEventDataFunction(triggerEvents),

--- a/ts/src/apps/stripe/triggers/subscription-updated.trigger.ts
+++ b/ts/src/apps/stripe/triggers/subscription-updated.trigger.ts
@@ -13,13 +13,6 @@ export default {
   action: 'subscription_updated',
   action_code: EQoreAppActionCode.EVENT,
   webhook_method: 'POST',
-  options: {
-    secretKey: {
-      required: true,
-      type: 'string',
-      sensitive: true,
-    },
-  },
   webhook_register: createRegisterStripeWebhookFunction(triggerEvents),
   webhook_deregister: deregisterStripeWebhook,
   get_example_event_data: createGetStripeExampleEventDataFunction(triggerEvents),

--- a/ts/src/qtests/stripe.qtest.ts
+++ b/ts/src/qtests/stripe.qtest.ts
@@ -347,8 +347,8 @@ describe('Tests Stripe Actions', () => {
     it('Should register stripe webhook', async () => {
       const result = await STRIPE_TRIGGERS['chargeSucceeded'].webhook_register(
         {
-          opts: {
-            secretKey: token,
+          conn_opts: {
+            token,
           },
         },
         'https://example1.com'
@@ -362,8 +362,8 @@ describe('Tests Stripe Actions', () => {
       if (webhook) {
         await STRIPE_TRIGGERS['chargeSucceeded'].webhook_deregister(
           {
-            opts: {
-              secretKey: token,
+            conn_opts: {
+              token,
             },
           },
           '',
@@ -373,8 +373,8 @@ describe('Tests Stripe Actions', () => {
     });
     it('Should get example stripe webhook data', async () => {
       const exampleData = await STRIPE_TRIGGERS['chargeSucceeded'].get_example_event_data({
-        opts: {
-          secretKey: token,
+        conn_opts: {
+          token,
         },
       });
 

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -9,7 +9,6 @@
     "target": "ES2021",
     "sourceMap": true,
     "outDir": "./dist",
-    "allowJs": true,
     "baseUrl": "./src",
     "paths": {
       "src/*": ["src/*"],
@@ -21,9 +20,6 @@
       "i18n/*": ["i18n/*"]
     },
     "plugins": [
-      {
-        "transform": "typescript-transform-paths"
-      },
       {
         "transform": "typescript-transform-paths",
         "afterDeclarations": true


### PR DESCRIPTION
As we now have webhook creation rights for the Stripe app there is no need for the API key options for triggers. 