### PR TITLE
feat: add in-process JavaScript program pool

### DIFF
--- a/design/in-process-pool.md
+++ b/design/in-process-pool.md
@@ -1,0 +1,177 @@
+Copyright 2026 Qore Technologies, s.r.o.
+
+# In-Process JavaScript Program Pool
+
+## Overview
+`JavaScriptInProcessPool` manages a pool of identical `JavaScriptProgram` instances
+for concurrent thread access **without IPC overhead**. Unlike the out-of-process
+`JavaScriptThreadProcessPool` (which spawns `ts-proxy` child processes and
+communicates over UNIX sockets with YAML serialization), the in-process pool runs
+JavaScript directly in the Qore process via V8 isolates.
+
+Each pool program is a full clone of the original: same source, same init code,
+same closures. The pool creates programs on demand when all existing ones are busy,
+up to an optional maximum size. When the maximum is reached, requesting threads
+block until a program becomes available.
+
+## Architecture
+
+```
+                    ┌─────────────────────────┐
+                    │ TypeScriptActionInterface│
+                    │                         │
+                    │  checkInProcessServer()──┼──► returns JavaScriptInProcessPool
+                    └─────────────┬───────────┘
+                                  │
+                    ┌─────────────▼───────────┐
+                    │ JavaScriptInProcessPool  │
+                    │                         │
+                    │  get() ──► InProcessProgramInfo (per-thread)
+                    │  release()              │
+                    │  execCall() ── get/call/release
+                    │  shutdown()             │
+                    │                         │
+                    │  imap: idle programs    │
+                    │  amap: active programs  │
+                    │  tmap: thread→program   │
+                    └─────────────────────────┘
+                                  │
+                    ┌─────────────▼───────────┐
+                    │ JavaScriptProgramPool    │
+                    │  createProgramForPool()  │
+                    │  (clone source + init)   │
+                    └─────────────────────────┘
+```
+
+### Dispatch Priority
+When a data provider executes an async call, the dispatch order is:
+1. **In-process pool** (`checkInProcessServer()`) — lowest latency
+2. **Out-of-process pool** (`checkServer()`) — IPC via ts-proxy
+3. **Single-program direct** — serialized on one program
+
+## Usage
+
+### On-Demand Pool (Recommended)
+The simplest approach: configure on-demand creation and let the pool be lazily
+created on first use.
+
+```qore
+# Enable on-demand with a pool size limit of 8 programs
+TypeScriptActionInterface::startInProcessServerOnDemand(NOTHING, 8);
+
+# The pool is created automatically on first checkInProcessServer() call.
+# All data provider dispatch (execAsyncValueArgs, getDynamicDataType, etc.)
+# will use the in-process pool transparently.
+
+# To shut down:
+TypeScriptActionInterface::shutdownInProcessServer();
+TypeScriptActionInterface::disableInProcessServerOnDemand();
+```
+
+### On-Demand with Specific Pool
+If you have a specific `JavaScriptProgramPool` to use (e.g., from a particular
+script), pass it explicitly:
+
+```qore
+JavaScriptProgramPool my_pool(source, path, init_callback);
+
+# Use this specific pool for in-process server creation
+TypeScriptActionInterface::startInProcessServerOnDemand(my_pool, 4);
+```
+
+### Direct Pool Injection
+For full control, create the pool yourself and inject it:
+
+```qore
+JavaScriptProgramPool pool(source, path, init_callback);
+JavaScriptInProcessPool ip(pool, 16);  # max 16 concurrent programs
+
+TypeScriptActionInterface::setInProcessServer(ip);
+
+# Later:
+TypeScriptActionInterface::shutdownInProcessServer();
+```
+
+### Via DataProvider Options
+In a server environment, set the `DPO_EnableInProcessServers` option before
+initialization:
+
+```qore
+DataProvider::addOptions(DPO_EnableInProcessServers);
+```
+
+This causes `TypeScriptActionInterface::init()` to set `in_process_on_demand = True`,
+so the pool is lazily created on first use.
+
+### Direct Pool API
+You can also use the pool directly without the `TypeScriptActionInterface` wrapper:
+
+```qore
+JavaScriptProgramPool pool(source, path, init_callback);
+JavaScriptInProcessPool ip(pool, 4);
+
+# Acquire a program for this thread
+hash<InProcessProgramInfo> info = ip.get();
+on_exit ip.release(info);
+
+# Use info.pgm (the JavaScriptProgram) directly
+# Or use info.call_map to look up closures by key
+
+# For dispatching via the standard async call path:
+auto result = ip.execCall(api_info, args);
+```
+
+## Pool Sizing
+
+- **`NOTHING` (unlimited)**: Pool grows without bound. Each program is a V8
+  isolate with its own heap, so unbounded growth can consume significant memory.
+  Use only when the number of concurrent threads is naturally limited.
+
+- **Fixed `max_size`**: Threads beyond the limit block in `get()` until a program
+  is released. Choose based on expected concurrency and available memory.
+  A reasonable starting point is the number of CPU cores.
+
+## Clone Mode (Internals)
+
+When the pool creates a new program, it must capture the JavaScript closures
+(API functions, option resolvers, event handlers, etc.) that get registered
+during `init()`. These closures are program-specific — each V8 isolate has its
+own function objects.
+
+The **clone mode** mechanism uses thread-local state to capture closures without
+modifying the global `acmap`:
+
+1. `PoolCloneModeHelper` sets `_pool_clone_mode = True` (thread-local)
+2. `JavaScriptProgramPool::createProgramForPool()` creates the program and
+   runs `init(pgm)`
+3. During init, `registerAppActions()` triggers the normal registration path
+4. `registerAsyncCall()` checks `_pool_clone_mode` and writes to
+   `_pool_clone_closures` instead of `acmap`
+5. `captureAppClosures()` and `captureActionClosures()` handle app-level and
+   action-level closures respectively, including REST modifier closures
+   (`post_auth`, `conn_update`) and dependent option closures
+6. `PoolCloneModeHelper`'s destructor restores the thread-local state
+7. The captured closures become the program's `call_map`
+
+At dispatch time, `execCall()` looks up the original `acmap` key in the
+program's `call_map` to find the equivalent closure for that program.
+
+## Thread Safety
+
+- **Pool mutex**: All pool state (imap, amap, tmap) is protected by a single
+  mutex. The mutex is released during program creation to avoid blocking other
+  threads.
+
+- **Creating counter**: Tracks in-flight program creations so `max_size` is
+  enforced even when multiple threads are creating programs concurrently.
+
+- **Condition variable**: Threads waiting for a program at `max_size` block on
+  a condition variable. They are woken by `release()`, failed creation
+  (`cond.signal()`), or `shutdown()` (`cond.broadcast()`).
+
+- **chdir mutex**: `JavaScriptProgramPool::createProgramForPool()` uses a
+  static mutex to serialize `chdir()` calls, since `chdir()` is process-global.
+
+- **Shutdown**: `shutdown()` sets a flag and broadcasts to all waiters. It can
+  be called while threads are still executing methods on the pool. After
+  shutdown, `get()` throws `POOL-SHUTDOWN`.

--- a/docs/mainpage.dox.tmpl
+++ b/docs/mainpage.dox.tmpl
@@ -432,6 +432,151 @@ var keys = Object.keys(qore.Qore);
 // keys contains namespace names, class names, function names, constants, and enums
     @endcode
 
+    @section v8_inprocess_pool In-Process JavaScript Program Pool
+
+    The @ref TypeScriptActionInterface::JavaScriptInProcessPool "JavaScriptInProcessPool" class manages a pool
+    of identical @ref V8::JavaScriptProgram "JavaScriptProgram" instances for concurrent thread access
+    <b>without IPC overhead</b>. Unlike the out-of-process pool (which spawns child processes and communicates
+    over UNIX sockets with YAML serialization), the in-process pool runs JavaScript directly in the %Qore
+    process via V8 isolates.
+
+    Each pool program is a full clone of the original: same source, same init code, same closures. The pool
+    creates programs on demand when all existing ones are busy, up to an optional maximum size. When the
+    maximum is reached, requesting threads block until a program becomes available.
+
+    @subsection v8_inprocess_pool_dispatch Dispatch Priority
+
+    When a data provider executes an async call, the dispatch order is:
+    -# <b>In-process pool</b> — lowest latency, no IPC overhead
+    -# <b>Out-of-process pool</b> — IPC via \c ts-proxy child processes
+    -# <b>Single-program direct</b> — serialized on one program
+
+    @subsection v8_inprocess_pool_ondemand On-Demand Pool (Recommended)
+
+    The simplest approach: enable on-demand creation and let the pool be lazily created on first use.
+    All data provider dispatch will use the in-process pool transparently.
+
+    @code{.py}
+%requires TypeScriptActionInterface
+
+# Enable on-demand with a pool size limit of 8 programs
+TypeScriptActionInterface::startInProcessServerOnDemand(NOTHING, 8);
+
+# The pool is created automatically on first checkInProcessServer() call.
+# All data provider dispatch (execAsyncValueArgs, getDynamicDataType, etc.)
+# will use the in-process pool transparently.
+
+# To shut down cleanly:
+TypeScriptActionInterface::shutdownInProcessServer();
+TypeScriptActionInterface::disableInProcessServerOnDemand();
+    @endcode
+
+    @subsection v8_inprocess_pool_ondemand_pool On-Demand with Specific Pool
+
+    If you have a specific @ref TypeScriptActionInterface::JavaScriptProgramPool "JavaScriptProgramPool"
+    (e.g., from a particular script), pass it explicitly:
+
+    @code{.py}
+%requires TypeScriptActionInterface
+
+JavaScriptProgramPool my_pool(source, path, init_callback);
+
+# Use this specific pool for in-process server creation, max 4 concurrent programs
+TypeScriptActionInterface::startInProcessServerOnDemand(my_pool, 4);
+    @endcode
+
+    @subsection v8_inprocess_pool_direct Direct Pool Injection
+
+    For full control, create the pool yourself and inject it:
+
+    @code{.py}
+%requires TypeScriptActionInterface
+
+JavaScriptProgramPool pool(source, path, init_callback);
+JavaScriptInProcessPool ip(pool, 16);  # max 16 concurrent programs
+
+TypeScriptActionInterface::setInProcessServer(ip);
+
+# Later:
+TypeScriptActionInterface::shutdownInProcessServer();
+    @endcode
+
+    @subsection v8_inprocess_pool_dp Via DataProvider Options
+
+    In a server environment, set the \c DPO_EnableInProcessServers option before initialization:
+
+    @code{.py}
+DataProvider::addOptions(DPO_EnableInProcessServers);
+    @endcode
+
+    This causes \c TypeScriptActionInterface::init() to set the on-demand flag so the pool is lazily
+    created on first use.
+
+    @subsection v8_inprocess_pool_direct_api Direct Pool API
+
+    The pool can also be used directly without the \c TypeScriptActionInterface wrapper:
+
+    @code{.py}
+%requires TypeScriptActionInterface
+
+JavaScriptProgramPool pool(source, path, init_callback);
+JavaScriptInProcessPool ip(pool, 4);
+
+# Acquire a program for this thread
+hash<InProcessProgramInfo> info = ip.get();
+on_exit ip.release(info);
+
+# Use info.pgm (the JavaScriptProgram) directly
+auto result = info.pgm.callFunction("myFunction", args);
+
+# Or use info.call_map to look up closures by key
+code my_closure = info.call_map{api_key};
+auto result = my_closure(args);
+    @endcode
+
+    For dispatching via the standard async call path:
+
+    @code{.py}
+auto result = ip.execCall(api_info, args);
+    @endcode
+
+    @subsection v8_inprocess_pool_concurrent Concurrent Access Example
+
+    The pool handles concurrent access transparently. Each thread gets its own program:
+
+    @code{.py}
+%requires TypeScriptActionInterface
+
+JavaScriptProgramPool pool(source, path, init_callback);
+# Create a bounded pool with max 4 concurrent programs
+JavaScriptInProcessPool ip(pool, 4);
+
+# Launch 8 threads — 4 will execute concurrently, 4 will wait
+list<int> tids;
+Counter done(8);
+for (int i = 0; i < 8; ++i) {
+    tids += background sub () {
+        on_exit done.dec();
+        hash<InProcessProgramInfo> info = ip.get();
+        on_exit ip.release(info);
+
+        # Each thread has its own V8 isolate — no serialization
+        auto result = info.pgm.callFunction("computeResult", (i,));
+    }();
+}
+done.waitForZero();
+ip.shutdown();
+    @endcode
+
+    @subsection v8_inprocess_pool_sizing Pool Sizing
+
+    - <b>\c NOTHING (unlimited)</b>: Pool grows without bound. Each program is a V8
+      isolate with its own heap, so unbounded growth can consume significant memory.
+      Use only when the number of concurrent threads is naturally limited.
+    - <b>Fixed \c max_size</b>: Threads beyond the limit block in \c get() until a program
+      is released. Choose based on expected concurrency and available memory.
+      A reasonable starting point is the number of CPU cores.
+
     @section javascript_javascript_to_qore JavaScript to Qore Data Conversions
 
     |!Source JavaScript Type|!Target %Qore Type
@@ -502,6 +647,21 @@ JavaScriptProgram::setSaveReferenceCallback(callback);
     @endcode
 
     @section v8releasenotes v8 Module Release Notes
+
+    @subsection v8_2_2 v8 Module Version 2.2
+    - added the @ref TypeScriptActionInterface::JavaScriptInProcessPool "JavaScriptInProcessPool" class for
+      concurrent in-process JavaScript execution without IPC overhead
+      (<a href="https://github.com/qoretechnologies/module-v8/issues/225">issue 225</a>)
+    - added @ref TypeScriptActionInterface::InProcessProgramInfo "InProcessProgramInfo" hashdecl
+    - added on-demand pool creation via
+      @ref TypeScriptActionInterface::TypeScriptActionInterface::startInProcessServerOnDemand()
+      "TypeScriptActionInterface::startInProcessServerOnDemand()" with configurable maximum pool size
+    - added direct pool injection via
+      @ref TypeScriptActionInterface::TypeScriptActionInterface::setInProcessServer()
+      "TypeScriptActionInterface::setInProcessServer()"
+    - added clone-mode closure capture mechanism using thread-local
+      @ref TypeScriptActionInterfacePriv::Priv::PoolCloneModeHelper "PoolCloneModeHelper" to create
+      pool programs without modifying global state
 
     @subsection v8_2_1 v8 Module Version 2.1
     - added the @ref V8::TypeScriptProgram "TypeScriptProgram" class for runtime TypeScript transpilation and

--- a/qlib/TypeScriptActionInterface/JavaScriptInProcessPool.qc
+++ b/qlib/TypeScriptActionInterface/JavaScriptInProcessPool.qc
@@ -1,0 +1,296 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore TypeScriptActionInterface module definition
+
+/*  JavaScriptInProcessPool.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Main namespace for the TypeScriptActionInterface module
+public namespace TypeScriptActionInterface {
+#! Information about an in-process program instance in the pool
+public hashdecl InProcessProgramInfo {
+    #! The JavaScript program instance
+    JavaScriptProgram pgm;
+
+    #! Map from original acmap keys to this program's closures
+    hash<string, code> call_map;
+
+    #! Unique ID for this program
+    string id;
+
+    #! Assigned thread ID (NOTHING when idle)
+    *int tid;
+
+    #! Last access time (NOTHING when active)
+    *date atime;
+
+    #! Event source count
+    int ecount = 0;
+}
+
+#! In-process pool of JavaScriptProgram instances for concurrent access
+/** This class manages a pool of identical JavaScriptProgram instances that allows concurrent thread access
+    without IPC overhead. Programs are created on demand when all existing programs are busy, up to an
+    optional maximum size. When the maximum is reached, threads wait for a program to become available.
+*/
+public class JavaScriptInProcessPool {
+    public {
+        #! Minimum number of pre-allocated programs
+        const MinPrograms = 1;
+    }
+
+    private {
+        #! Pool mutex
+        Mutex m();
+
+        #! Condition variable for threads waiting when pool is at max size
+        Condition cond();
+
+        #! Thread map: TID -> program unique ID
+        hash<string, string> tmap;
+
+        #! Active programs: unique ID -> InProcessProgramInfo
+        hash<string, hash<InProcessProgramInfo>> amap;
+
+        #! Idle programs: unique ID -> InProcessProgramInfo
+        hash<string, hash<InProcessProgramInfo>> imap;
+
+        #! Number of threads waiting for a program to become available
+        int waiting = 0;
+
+        #! Number of programs currently being created (to enforce max_size during concurrent creation)
+        int creating = 0;
+
+        #! The JavaScriptProgramPool used to create new programs
+        JavaScriptProgramPool pool;
+
+        #! Maximum pool size (NOTHING = unlimited)
+        *int max_size;
+
+        #! Shutdown flag
+        bool shutdown_flag = False;
+    }
+
+    #! Creates the pool with at least MinPrograms pre-allocated
+    /** @param pool the JavaScriptProgramPool used to create new programs
+        @param max_size optional maximum number of programs in the pool; NOTHING = unlimited
+    */
+    constructor(JavaScriptProgramPool pool, *int max_size) {
+        self.pool = pool;
+        self.max_size = max_size;
+
+        # pre-allocate minimum number of programs
+        for (int i = 0; i < MinPrograms; ++i) {
+            hash<InProcessProgramInfo> info = createProgramIntern();
+            imap{info.id} = info;
+        }
+        TSAI::info("JavaScriptInProcessPool: created with %d pre-allocated program(s), max_size: %y",
+            MinPrograms, max_size);
+    }
+
+    #! Shuts down the pool and deletes all programs
+    destructor() {
+        shutdown();
+    }
+
+    #! Signals shutdown and wakes all waiting threads
+    /** Can be called while threads are still executing methods on this object.
+        After calling shutdown(), any thread blocked in get() will throw POOL-SHUTDOWN,
+        and new calls to get() will also throw POOL-SHUTDOWN.
+    */
+    shutdown() {
+        m.lock();
+        on_exit m.unlock();
+
+        shutdown_flag = True;
+        if (amap) {
+            TSAI::error("JavaScriptInProcessPool: shutting down with %d active program(s)", amap.size());
+        }
+        # delete all idle programs
+        remove imap;
+        # delete all active programs
+        remove amap;
+        remove tmap;
+
+        if (waiting) {
+            cond.broadcast();
+        }
+    }
+
+    #! Returns a unique hash for the pool (for DataProvider shutdown handler registration)
+    string uniqueHash() {
+        return pool.uniqueHash() + "-inprocess";
+    }
+
+    #! Acquires a program for the calling thread
+    /** If the calling thread already has a program assigned, returns it.
+        Otherwise, takes an idle program, waits for one to become available (if at max size),
+        or creates a new one.
+
+        @return the program info for the calling thread
+    */
+    hash<InProcessProgramInfo> get() {
+        int tid = gettid();
+
+        m.lock();
+        on_exit m.unlock();
+
+        if (shutdown_flag) {
+            throw "POOL-SHUTDOWN", "In-process pool is shutting down";
+        }
+
+        # check if this thread already has a program
+        if (*string pkey = tmap{tid}) {
+            return amap{pkey};
+        }
+
+        hash<InProcessProgramInfo> info;
+        string pkey;
+
+        if (imap) {
+            # take from idle map
+            pkey = imap.firstKey();
+            info = remove imap{pkey};
+            remove info.atime;
+        } else if (exists max_size && (amap.size() + creating >= max_size)) {
+            # at max size (including in-flight creations); wait for a program to be released
+            ++waiting;
+            on_exit --waiting;
+            while (!imap && !shutdown_flag) {
+                cond.wait(m);
+            }
+            if (shutdown_flag) {
+                throw "POOL-SHUTDOWN", "In-process pool shut down while waiting for program";
+            }
+            pkey = imap.firstKey();
+            info = remove imap{pkey};
+            remove info.atime;
+        } else {
+            # create a new program (release mutex during creation)
+            # track in-flight creations so max_size is enforced across concurrent creators
+            ++creating;
+            try {
+                {
+                    m.unlock();
+                    on_exit m.lock();
+                    info = createProgramIntern();
+                }
+            } catch () {
+                # on_exit m.lock() has already re-acquired the mutex
+                --creating;
+                # wake a waiter so it can retry creation now that creating has dropped
+                if (waiting) {
+                    cond.signal();
+                }
+                rethrow;
+            }
+            --creating;
+            # mutex is re-acquired here
+            if (shutdown_flag) {
+                throw "POOL-SHUTDOWN", "In-process pool shut down during program creation";
+            }
+            pkey = info.id;
+        }
+
+        info.tid = tid;
+        amap{pkey} = info;
+        tmap{tid} = pkey;
+        return info;
+    }
+
+    #! Releases a program back to the idle pool
+    /** Must be called after get() when the caller is done with the program.
+        Safe to call after shutdown() — the call is a no-op if the program is no longer in the active map.
+
+        @param info the program info returned by get()
+    */
+    release(hash<InProcessProgramInfo> info) {
+        m.lock();
+        on_exit m.unlock();
+
+        releaseIntern(info);
+    }
+
+    #! Releases a program back to the idle pool (must be called with mutex locked)
+    private releaseIntern(hash<InProcessProgramInfo> info) {
+        string pkey = info.id;
+        if (!amap{pkey}) {
+            return;
+        }
+        remove amap{pkey};
+        if (info.tid) {
+            remove tmap{info.tid};
+        }
+        remove info.tid;
+        info.atime = now_us();
+        imap{pkey} = info;
+
+        if (waiting) {
+            cond.signal();
+        }
+    }
+
+    #! Core dispatch method: acquires a program, executes the call, and releases
+    /** @param api the async call info (from the global acmap)
+        @param args optional arguments to pass to the call
+
+        @return the result of the call
+    */
+    auto execCall(hash<AsyncCallInfo> api, *softlist<auto> args) {
+        hash<InProcessProgramInfo> info = get();
+        on_exit release(info);
+
+        # look up the equivalent closure for this pooled program
+        *code pooled_call = info.call_map{api.key};
+        if (!pooled_call) {
+            throw "POOL-CALL-ERROR", sprintf("No pooled closure for key %y in program %y; known keys: %y",
+                api.key, info.id, keys info.call_map);
+        }
+
+        # build a modified AsyncCallInfo with the pooled closure
+        hash<AsyncCallInfo> pooled_api = api;
+        pooled_api.async_call = pooled_call;
+
+        return TypeScriptActionDataProviderBase::execAsyncValueDirect(DataProvider::getGlobalLogger(),
+            pooled_api, args);
+    }
+
+    #! Creates a new program with closures captured via clone mode
+    private hash<InProcessProgramInfo> createProgramIntern() {
+        TSAI::info("JavaScriptInProcessPool: creating new program");
+        date start = now_us();
+
+        # Set clone mode to capture closures
+        PoolCloneModeHelper clone_helper();
+        JavaScriptProgram new_pgm = pool.createProgramForPool();
+        *hash<string, code> closures = PoolCloneModeHelper::getClosures();
+
+        TSAI::info("JavaScriptInProcessPool: created new program in %y with %d closure(s)",
+            now_us() - start, closures.size());
+
+        string id = new_pgm.uniqueHash();
+        return <InProcessProgramInfo>{
+            "pgm": new_pgm,
+            "call_map": closures ?? {},
+            "id": id,
+        };
+    }
+}
+}

--- a/qlib/TypeScriptActionInterface/JavaScriptProgramPool.qc
+++ b/qlib/TypeScriptActionInterface/JavaScriptProgramPool.qc
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 #! Qore TypeScriptActionInterface module definition
 
-/*  JavaScriptProgramPool.qc Copyright 2024 Qore Technologies, s.r.o.
+/*  JavaScriptProgramPool.qc Copyright 2024 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -51,6 +51,9 @@ public class JavaScriptProgramPool {
 
         # indicates the first program unique hash for each holder
         static hash<string, bool> firstmap;
+
+        #! Mutex to serialize chdir() calls during program creation (chdir is process-global)
+        static Mutex chdir_mutex();
     }
 
     #! Creates the object and the JavaScript program
@@ -95,7 +98,57 @@ public class JavaScriptProgramPool {
         return pool;
     }
 
+    #! Returns the JavaScript source code
+    string getSource() {
+        return source;
+    }
+
+    #! Returns the JavaScript source path
+    string getPath() {
+        return path;
+    }
+
+    #! Returns the current working directory
+    string getCwd() {
+        return cwd;
+    }
+
+    #! Returns the initialization code
+    code getInit() {
+        return init;
+    }
+
+    #! Creates a new JavaScriptProgram for use in an in-process pool
+    /** The caller must set _pool_clone_mode before calling this method to capture closures
+        without modifying global state.
+
+        @return a new JavaScriptProgram with the same source and init code
+    */
+    JavaScriptProgram createProgramForPool() {
+        # serialize chdir() calls — chdir is process-global and concurrent calls race
+        chdir_mutex.lock();
+        on_exit chdir_mutex.unlock();
+
+        string olddir = getcwd();
+        chdir(cwd);
+        on_exit chdir(olddir);
+
+        date start = now_us();
+        on_exit info("perf: JavaScriptProgramPool new pool program for %y: %y", path, now_us() - start);
+
+        JavaScriptProgram new_pgm = new JavaScriptProgram(source, path);
+        string h0 = new_pgm.uniqueHash();
+        pmap{h0} = self;
+        on_error remove pmap{h0};
+        init(new_pgm);
+        return new_pgm;
+    }
+
     private createProgram(*bool first) {
+        # serialize chdir() calls — chdir is process-global and concurrent calls race
+        chdir_mutex.lock();
+        on_exit chdir_mutex.unlock();
+
         string olddir = getcwd();
         chdir(cwd);
         on_exit chdir(olddir);

--- a/qlib/TypeScriptActionInterface/TypeScriptActionDataProviderBase.qc
+++ b/qlib/TypeScriptActionInterface/TypeScriptActionDataProviderBase.qc
@@ -1,6 +1,6 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-/*  TypeScriptActionDataProviderBase.qc Copyright (C) 2023 - 2024 Qore Technologies s.r.o.
+/*  TypeScriptActionDataProviderBase.qc Copyright (C) 2023 - 2026 Qore Technologies s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -214,6 +214,11 @@ public class TypeScriptActionDataProviderBase inherits AbstractDataProvider, Act
         on_exit TSAI::debug("perf: %y get async value: %y (args: %y)", api.label, now_us() - start, args);
         on_error TSAI::error("%s", get_exception_string($1));
 
+        # check in-process pool first (no IPC overhead)
+        if (*JavaScriptInProcessPool ip = TSAI::checkInProcessServer()) {
+            return ip.execCall(api, args);
+        }
+
         # handle the call with a remote process
         if (TSAI::checkServer()) {
             TSAI::info("%y: acquiring proxy for %y: %y", api.label, api.key, LoggerUtil::getArgSummary(args));
@@ -222,6 +227,27 @@ public class TypeScriptActionDataProviderBase inherits AbstractDataProvider, Act
             on_exit TypeScriptActionInterface::server.release(proxy);
             return proxy.getAsyncValue(api, args);
         }
+
+        return execAsyncValueDirect(logger, api, args);
+    }
+
+    #! Executes the async call directly (no pool/server dispatch)
+    /** Called from execAsyncValueArgs() when no pool or server is active, and from
+        JavaScriptInProcessPool::execCall() to avoid re-entering the pool check.
+
+        @param logger optional logger for post-processing callbacks
+        @param api the async call info
+        @param args optional arguments to pass to the call
+
+        @return the result of the call
+    */
+    static auto execAsyncValueDirect(*LoggerInterface logger, hash<AsyncCallInfo> api, *softlist<auto> args) {
+        if (_ts_no_io) {
+            return;
+        }
+        date start = now_us();
+        on_exit TSAI::debug("perf: %y direct async value: %y (args: %y)", api.label, now_us() - start, args);
+        on_error TSAI::error("%s", get_exception_string($1));
 
         auto v;
         try {
@@ -474,7 +500,15 @@ public class TypeScriptActionDataProviderBase inherits AbstractDataProvider, Act
         }
 
         *hash<string, hash<ActionOptionInfo>> rv;
-        if (TSAI::checkServer()) {
+        if (TSAI::checkInProcessServer()) {
+            # in-process pool uses the same path as direct execution
+            TSAI::debug("getActionOptionsWithOptions() in-process pool exec options: %y slice: %y", options,
+                keys slice);
+            rv = getActionOptionsWithOptionsIntern({
+                "app": app,
+                "action": action,
+            }, slice, options);
+        } else if (TSAI::checkServer()) {
             TSAI::debug("Starting proxy for app %y action %y: plain dynamic type with args: %y", app, action, options);
             JavaScriptProgramProxy proxy = TypeScriptActionInterface::server.get();
             TSAI::debug("Proxy started for app %y action %y: plain dynamic type with args", app, action);
@@ -517,7 +551,10 @@ public class TypeScriptActionDataProviderBase inherits AbstractDataProvider, Act
         }
 
         *HashDataType type;
-        if (TSAI::checkServer()) {
+        if (TSAI::checkInProcessServer()) {
+            # in-process pool uses the same path as direct execution
+            type = getDynamicOptionTypeIntern(rt, slice, req);
+        } else if (TSAI::checkServer()) {
             TSAI::debug("Starting proxy for app %y action %y: dynamic type with args: %y", app, action,
                 LoggerUtil::getArgSummary(req));
             JavaScriptProgramProxy proxy = TypeScriptActionInterface::server.get();

--- a/qlib/TypeScriptActionInterface/TypeScriptActionEventDataProvider.qc
+++ b/qlib/TypeScriptActionInterface/TypeScriptActionEventDataProvider.qc
@@ -1,6 +1,6 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-/*  TypeScriptActionEventDataProvider.qc Copyright (C) 2023 - 2024 Qore Technologies s.r.o.
+/*  TypeScriptActionEventDataProvider.qc Copyright (C) 2023 - 2026 Qore Technologies s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -178,7 +178,17 @@ public class TypeScriptActionEventDataProvider inherits TypeScriptActionEventDat
         m.lock();
         on_exit m.unlock();
 
-        if (TSAI::checkServer()) {
+        if (TSAI::checkInProcessServer()) {
+            # in-process pool uses the direct event thread path
+            info("Starting in-process event thread for data provider %y for connection %y options %y", name,
+                conn.name, event_options);
+            running = True;
+            on_error running = False;
+            Counter c(1);
+            int tid = background startEventThread(c);
+            c.waitForZero();
+            info("Started in-process event thread in TID %d", tid);
+        } else if (TSAI::checkServer()) {
             info("Starting external process for data provider %y for connection %y options %y", name, conn.name,
                 event_options);
             running = True;

--- a/qlib/TypeScriptActionInterface/TypeScriptActionInterface.qc
+++ b/qlib/TypeScriptActionInterface/TypeScriptActionInterface.qc
@@ -290,6 +290,18 @@ public class TypeScriptActionInterface {
 
         #! On-demand server flag
         static bool on_demand;
+
+        #! In-process pool for concurrent access without IPC overhead
+        static JavaScriptInProcessPool in_process_server;
+
+        #! In-process on-demand flag
+        static bool in_process_on_demand;
+
+        #! Optional pool for on-demand in-process server creation
+        static *JavaScriptProgramPool in_process_on_demand_pool;
+
+        #! Optional maximum pool size for on-demand in-process server creation
+        static *int in_process_max_size;
     }
 
     #! Performs static initialization of the module
@@ -299,6 +311,8 @@ public class TypeScriptActionInterface {
         int opts = DataProvider::getOptions();
         if (opts & DPO_EnableServers) {
             on_demand = True;
+        } else if (opts & DPO_EnableInProcessServers) {
+            in_process_on_demand = True;
         }
         if (opts & DPO_DisableOnDemandInitialization) {
             TypeScriptActionInterface::initAllApps(opts & DPO_EnableOnDemandActions ? False : True);
@@ -437,6 +451,110 @@ public class TypeScriptActionInterface {
         delete server;
     }
 
+    #! Returns the first registered JavaScriptProgramPool, if any
+    static *JavaScriptProgramPool getFirstPool() {
+        return TypeScriptActionInterfacePriv::getFirstPool();
+    }
+
+    #! Sets the in-process server to start on demand
+    /** @param pool optional specific pool to use; if not provided, uses the first registered pool
+        @param max_size optional maximum number of programs in the pool; NOTHING = unlimited
+    */
+    static startInProcessServerOnDemand(*JavaScriptProgramPool pool, *int max_size) {
+        sm.lock();
+        on_exit sm.unlock();
+
+        in_process_on_demand = True;
+        in_process_on_demand_pool = pool;
+        in_process_max_size = max_size;
+    }
+
+    #! Sets the in-process server directly
+    /** Replaces any existing in-process server with the given pool instance.
+        The caller is responsible for creating the pool with the desired max_size.
+
+        @param ip the in-process pool to use as the server
+
+        @par Example:
+        @code{.py}
+        JavaScriptInProcessPool ip(pool, 8);
+        TypeScriptActionInterface::setInProcessServer(ip);
+        @endcode
+    */
+    static setInProcessServer(JavaScriptInProcessPool ip) {
+        sm.lock();
+        on_exit sm.unlock();
+
+        in_process_server = ip;
+    }
+
+    #! Disables on-demand in-process server creation and clears any stored pool/max_size configuration
+    static disableInProcessServerOnDemand() {
+        sm.lock();
+        on_exit sm.unlock();
+
+        in_process_on_demand = False;
+        remove in_process_on_demand_pool;
+        remove in_process_max_size;
+    }
+
+    #! Returns the in-process pool if active, starting it on demand if configured
+    /** Uses double-checked locking: first checks without the mutex for the fast path,
+        then acquires the mutex and checks again to avoid races during lazy creation.
+
+        @return the in-process pool, or NOTHING if not active and on-demand is not configured
+    */
+    static *JavaScriptInProcessPool checkInProcessServer() {
+        if (in_process_server) {
+            return in_process_server;
+        }
+        if (!in_process_on_demand) {
+            return;
+        }
+
+        # lock and check everything again in case of contention
+        sm.lock();
+        on_exit sm.unlock();
+        if (in_process_server) {
+            return in_process_server;
+        }
+        if (in_process_on_demand) {
+            TypeScriptActionInterface::startInProcessServerIntern();
+            return in_process_server;
+        }
+    }
+
+    #! Starts the in-process server using registered program pools
+    private static startInProcessServerIntern() {
+        # use the on-demand pool if set, otherwise find the first registered pool
+        *JavaScriptProgramPool pool = in_process_on_demand_pool ?? TypeScriptActionInterfacePriv::getFirstPool();
+        if (!pool) {
+            throw "IN-PROCESS-SERVER-ERROR", "Cannot start in-process server: no JavaScriptProgramPool available";
+        }
+
+        in_process_server = new JavaScriptInProcessPool(pool, in_process_max_size);
+        DataProvider::registerShutdownHandler(in_process_server.uniqueHash(),
+            \TypeScriptActionInterface::shutdownInProcessServer());
+    }
+
+    #! Shuts the in-process server down if it's running
+    /** Calls shutdown() on the pool (which wakes waiting threads and sets the shutdown flag)
+        rather than deleting the pool immediately, since concurrent threads may still be
+        executing against the pool via checkInProcessServer()->execCall().
+    */
+    static shutdownInProcessServer(*int signal) {
+        sm.lock();
+        on_exit sm.unlock();
+
+        *JavaScriptInProcessPool ip = remove in_process_server;
+        if (!ip) {
+            return;
+        }
+
+        DataProvider::deregisterShutdownHandler(ip.uniqueHash());
+        ip.shutdown();
+    }
+
     static string getCamelCaseAppName(string lc) {
         *string name = appcasemap{lc};
         if (!exists name) {
@@ -450,6 +568,12 @@ public class TypeScriptActionInterface {
         string key;
         try {
             key = (foldl $1 + "-" + $2, argv) + sprintf("-%s", call.type);
+            # in pool clone mode, capture closures without modifying global state
+            if (_pool_clone_mode) {
+                call.key = key;
+                _pool_clone_closures{key} = call.async_call;
+                return key;
+            }
             if (acmap{key} && ((acmap{key} - "key") == (call - "key"))) {
                 # function is being reused
                 return key;
@@ -471,6 +595,12 @@ public class TypeScriptActionInterface {
 
     static string registerAsyncCallArgs(reference<hash<AsyncCallInfo>> call, list<auto> args) {
         string key = (foldl $1 + "-" + $2, args) + sprintf("-%s", call.type);
+        # in pool clone mode, capture closures without modifying global state
+        if (_pool_clone_mode) {
+            call.key = key;
+            _pool_clone_closures{key} = call.async_call;
+            return key;
+        }
         if (acmap{key} && ((acmap{key} - "key") == (call - "key"))) {
             # function is being reused
             return key;
@@ -498,7 +628,7 @@ public class TypeScriptActionInterface {
             on_error rethrow "APP-ERROR", sprintf("Error registering app %y: %s", app.name, $1.desc);
             pool = JavaScriptProgramPool::getPool(pgm, \first);
         }
-        if (first) {
+        if (first || _pool_clone_mode) {
             TypeScriptActionInterface::registerApp(app.toData(), pool);
         }
     }
@@ -513,7 +643,7 @@ public class TypeScriptActionInterface {
             on_error rethrow "APP-ERROR", sprintf("Error registering existing app %y: %s", app.name, $1.desc);
             pool = JavaScriptProgramPool::getPool(pgm, \first);
         }
-        if (first) {
+        if (first || _pool_clone_mode) {
             TypeScriptActionInterface::registerExistingApp(app.toData(), pool);
         }
     }
@@ -529,35 +659,48 @@ public class TypeScriptActionInterface {
                 action.app, action.action, $1.desc);
             pool = JavaScriptProgramPool::getPool(pgm, \first);
         }
-        if (first) {
+        if (first || _pool_clone_mode) {
             TypeScriptActionInterface::registerAction(action.toData(), pool);
             TSAI::debug("Registered TypeScript app %y action %y: %s", action.app, action.action);
         }
     }
 
     static registerApp(hash<auto> app, JavaScriptProgramPool pool) {
-        if (app.name =~ / /) {
-            throw "APP-ERROR", sprintf("App name %y is invalid; it contains one or more spaces", app.name);
-        }
-        deregisterDynamicApp(app.name);
         string appname = app.name.lwr();
-        if (exists appcasemap{app.name}) {
-            if (IgnoreDuplicateAppHelper::get()) {
-                return;
+
+        if (!_pool_clone_mode) {
+            # Validation only needed for first registration
+            if (app.name =~ / /) {
+                throw "APP-ERROR", sprintf("App name %y is invalid; it contains one or more spaces", app.name);
             }
-            throw "APP-ERROR", sprintf("App %y has already been regstered and is pending initialization", app.name);
-        }
-        if (initmap{app.name}) {
-            if (IgnoreDuplicateAppHelper::get()) {
-                return;
+            deregisterDynamicApp(app.name);
+            if (exists appcasemap{app.name}) {
+                if (IgnoreDuplicateAppHelper::get()) {
+                    return;
+                }
+                throw "APP-ERROR", sprintf("App %y has already been regstered and is pending initialization",
+                    app.name);
             }
-            throw "APP-ERROR", sprintf("App %y has already been registered", app.name);
+            if (initmap{app.name}) {
+                if (IgnoreDuplicateAppHelper::get()) {
+                    return;
+                }
+                throw "APP-ERROR", sprintf("App %y has already been registered", app.name);
+            }
+            if (*hash<auto> info = DynamicAppContextHelper::get(app.name)) {
+                app += info;
+                DynamicAppContextHelper::addApp(app.name);
+                TSAI::info("Registering dynamic app with info: %N", info);
+            }
         }
-        if (*hash<auto> info = DynamicAppContextHelper::get(app.name)) {
-            app += info;
-            DynamicAppContextHelper::addApp(app.name);
-            TSAI::info("Registering dynamic app with info: %N", info);
+
+        if (_pool_clone_mode) {
+            # In clone mode, extract all app-level closures via the shared tryGetAsyncAttribute path.
+            # Also extract REST modifier closures that are normally registered in registerAppIntern.
+            captureAppClosures(app, pool);
+            return;
         }
+
         hash<AsyncCallInfo> get_table_list;
         hash<AsyncCallInfo> begin_transaction;
         hash<AsyncCallInfo> commit;
@@ -721,6 +864,10 @@ public class TypeScriptActionInterface {
     }
 
     static registerExistingApp(hash<auto> app, JavaScriptProgramPool pool) {
+        if (_pool_clone_mode) {
+            # In clone mode, existing apps have no JS closures to capture; skip
+            return;
+        }
         if (app.name.typeCode() != NT_STRING || !app.name.val()) {
             throw "APP-ERROR", sprintf("App name %y is invalid; must be a non-empty string", app.name);
         }
@@ -1513,6 +1660,11 @@ public class TypeScriptActionInterface {
     }
 
     static registerAction(hash<auto> action, JavaScriptProgramPool pool) {
+        if (_pool_clone_mode) {
+            # In clone mode, only extract async call closures; skip all global state registration
+            captureActionClosures(action, pool);
+            return;
+        }
         # register the action immediately if the app has already been registered
         if (initmap{action.app}) {
             TypeScriptActionInterface::registerActionIntern(action, pool);
@@ -1803,6 +1955,189 @@ public class TypeScriptActionInterface {
         action.action_val = event_id;
         action.path = action.action;
         return rv;
+    }
+
+    #! Extracts app-level async closures in pool clone mode without modifying global state
+    /** This method must be kept in sync with registerApp(hash, pool) and registerAppIntern().
+        It captures all closures that would normally be registered during app registration:
+        - Table/record closures: get_table_list, get_record_type, search_records, create_records,
+          update_records, upsert_records, delete_records (direct app attributes)
+        - REST modifier closures: post_auth (rest_modifiers.set_options_post_auth),
+          post_auth_code (rest_modifiers.set_options_post_auth_code),
+          conn_update (rest_modifiers.connection_update_option.code)
+    */
+    private static captureAppClosures(hash<auto> app, JavaScriptProgramPool pool) {
+        timeout io_timeout = seconds(app.io_timeout_secs ?? DefaultIoTimeoutSecs);
+        string name = app.name;
+
+        # Extract table/record async attribute closures (direct app attributes)
+        foreach string attr in ("get_table_list", "get_record_type", "search_records", "create_records",
+                "update_records", "upsert_records", "delete_records") {
+            tryGetAsyncAttribute(\app, attr, attr, pool, io_timeout, name);
+        }
+
+        # Extract REST modifier closures from their actual paths in the app hash
+        if (*hash<auto> rest_modifiers = app.rest_modifiers) {
+            if (rest_modifiers.set_options_post_auth.callp()) {
+                hash<AsyncCallInfo> call = <AsyncCallInfo>{
+                    "app": name,
+                    "type": "post_auth",
+                    "label": sprintf("clone: post_auth for app %y", name),
+                    "pool": pool,
+                    "async_call": rest_modifiers.set_options_post_auth,
+                    "to": seconds(rest_modifiers.io_timeout_secs ?? DefaultPostAuthIoTimeoutSecs),
+                };
+                TypeScriptActionInterface::registerAsyncCall(\call, "app", name);
+            }
+            if (rest_modifiers.set_options_post_auth_code.callp()) {
+                hash<AsyncCallInfo> call = <AsyncCallInfo>{
+                    "app": name,
+                    "type": "post_auth_code",
+                    "label": sprintf("clone: post_auth_code for app %y", name),
+                    "pool": pool,
+                    "async_call": rest_modifiers.set_options_post_auth_code,
+                    "to": seconds(rest_modifiers.io_timeout_secs ?? DefaultPostAuthIoTimeoutSecs),
+                };
+                TypeScriptActionInterface::registerAsyncCall(\call, "app", name);
+            }
+            if (rest_modifiers.connection_update_option.val()
+                    && rest_modifiers.connection_update_option."code".callp()) {
+                hash<AsyncCallInfo> call = <AsyncCallInfo>{
+                    "app": name,
+                    "type": "conn_update",
+                    "label": sprintf("clone: conn_update for app %y", name),
+                    "pool": pool,
+                    "async_call": rest_modifiers.connection_update_option."code",
+                    "to": seconds(rest_modifiers.io_timeout_secs ?? DefaultIoTimeoutSecs),
+                };
+                TypeScriptActionInterface::registerAsyncCall(\call, "app", name);
+            }
+        }
+    }
+
+    #! Extracts action-level async closures in pool clone mode without modifying global state
+    /** This method must be kept in sync with generateApiDataProvider() and generateEventDataProvider().
+        It captures all closures that would normally be registered during action registration:
+        - API closures: api_function, get_dynamic_request_type, get_dynamic_response_type,
+          request_data_converter, response_data_converter
+        - Event closures: get_dynamic_type, get_example_event_data, format_event_data, event_function
+        - Webhook closures: webhook_register, webhook_deregister
+        - Option closures: get_allowed_values, get_element_allowed_values, get_default_value,
+          get_dependent_options, get_dependent_response_options, get_dynamic_type
+    */
+    private static captureActionClosures(hash<auto> action, JavaScriptProgramPool pool) {
+        string app = action.app;
+        string act = action.action;
+        timeout io_timeout = seconds(action.io_timeout_secs ?? DefaultIoTimeoutSecs);
+
+        # API-level closures directly registered (matching key generation in generateApiDataProvider)
+        if (action.api_function.callp()) {
+            hash<AsyncCallInfo> call = <AsyncCallInfo>{
+                "app": app,
+                "action": act,
+                "type": "api_function",
+                "label": sprintf("clone: API function for app %y action %y", app, act),
+                "pool": pool,
+                "async_call": action.api_function,
+                "to": seconds(io_timeout),
+            };
+            TypeScriptActionInterface::registerAsyncCall(\call, "app", app, act);
+        }
+
+        # Closures registered with extra arg in key (type = "api_function", extra arg distinguishes them)
+        foreach string attr in ("get_dynamic_request_type", "get_dynamic_response_type",
+                "request_data_converter", "response_data_converter") {
+            if (action{attr}.callp()) {
+                hash<AsyncCallInfo> call = <AsyncCallInfo>{
+                    "app": app,
+                    "action": act,
+                    "type": "api_function",
+                    "label": sprintf("clone: %s for app %y action %y", attr, app, act),
+                    "pool": pool,
+                    "async_call": action{attr},
+                    "to": seconds(io_timeout),
+                };
+                TypeScriptActionInterface::registerAsyncCall(\call, "app", app, act, attr);
+            }
+        }
+
+        # Event-related closures (registered via tryGetAsyncAttribute or direct; type = attribute name)
+        foreach string attr in ("get_dynamic_type", "get_example_event_data", "format_event_data") {
+            tryGetAsyncAttribute(\action, attr, attr, pool, io_timeout, app, act);
+        }
+
+        # Event function (type = "event_function")
+        if (action.event_function.callp()) {
+            hash<AsyncCallInfo> call = <AsyncCallInfo>{
+                "app": app,
+                "action": act,
+                "type": "event_function",
+                "label": sprintf("clone: event function for app %y action %y", app, act),
+                "pool": pool,
+                "async_call": action.event_function,
+                "to": seconds(io_timeout),
+            };
+            TypeScriptActionInterface::registerAsyncCall(\call, "app", app, act);
+        }
+
+        # Webhook closures (type = "webhook_register" / "webhook_deregister")
+        foreach string attr in ("webhook_register", "webhook_deregister") {
+            if (action{attr}.callp()) {
+                hash<AsyncCallInfo> call = <AsyncCallInfo>{
+                    "app": app,
+                    "action": act,
+                    "type": attr,
+                    "label": sprintf("clone: %s for app %y action %y", attr, app, act),
+                    "pool": pool,
+                    "async_call": action{attr},
+                    "to": seconds(io_timeout),
+                };
+                TypeScriptActionInterface::registerAsyncCall(\call, "app", app, act);
+            }
+        }
+
+        # Option-level closures
+        if (action.options.typeCode() == NT_HASH) {
+            foreach hash<auto> i in (action.options.pairIterator()) {
+                if (i.value.typeCode() != NT_HASH) {
+                    continue;
+                }
+                # get_allowed_values, get_element_allowed_values, get_default_value
+                foreach string opt_attr in ("get_allowed_values", "get_element_allowed_values",
+                        "get_default_value") {
+                    if (i.value{opt_attr}.callp()) {
+                        hash<AsyncCallInfo> call = <AsyncCallInfo>{
+                            "app": app,
+                            "action": act,
+                            "type": opt_attr,
+                            "label": sprintf("clone: %s for app %y action %y option %y",
+                                opt_attr, app, act, i.key),
+                            "pool": pool,
+                            "async_call": i.value{opt_attr},
+                            "to": seconds(io_timeout),
+                        };
+                        TypeScriptActionInterface::registerAsyncCall(\call, "app", app, act, i.key);
+                    }
+                }
+                # Dependent option closures
+                foreach string dep_attr in ("get_dependent_options", "get_dependent_response_options",
+                        "get_dynamic_type") {
+                    if (i.value{dep_attr}.callp()) {
+                        hash<AsyncCallInfo> call = <AsyncCallInfo>{
+                            "app": app,
+                            "action": act,
+                            "type": dep_attr,
+                            "label": sprintf("clone: %s for app %y action %y option %y",
+                                dep_attr, app, act, i.key),
+                            "pool": pool,
+                            "async_call": i.value{dep_attr},
+                            "to": seconds(io_timeout),
+                        };
+                        TypeScriptActionInterface::registerAsyncCall(\call, "app", app, act, i.key);
+                    }
+                }
+            }
+        }
     }
 
     static *hash<AsyncCallInfo> tryGetAsyncAttribute(reference<hash<auto>> h, string key, string type,

--- a/qlib/TypeScriptActionInterface/TypeScriptActionInterface.qc
+++ b/qlib/TypeScriptActionInterface/TypeScriptActionInterface.qc
@@ -678,7 +678,7 @@ public class TypeScriptActionInterface {
                 if (IgnoreDuplicateAppHelper::get()) {
                     return;
                 }
-                throw "APP-ERROR", sprintf("App %y has already been regstered and is pending initialization",
+                throw "APP-ERROR", sprintf("App %y has already been registered and is pending initialization",
                     app.name);
             }
             if (initmap{app.name}) {
@@ -879,7 +879,7 @@ public class TypeScriptActionInterface {
             if (IgnoreDuplicateAppHelper::get()) {
                 return;
             }
-            throw "APP-ERROR", sprintf("App %y has already been regstered and is pending initialization", app.name);
+            throw "APP-ERROR", sprintf("App %y has already been registered and is pending initialization", app.name);
         }
         if (initmap{app.name}) {
             if (IgnoreDuplicateAppHelper::get()) {

--- a/qlib/TypeScriptActionInterface/TypeScriptActionInterface.qm
+++ b/qlib/TypeScriptActionInterface/TypeScriptActionInterface.qm
@@ -77,6 +77,27 @@ module TypeScriptActionInterface {
 
     @section TypeScriptActionInterface_relnotes Release Notes
 
+    @subsection TypeScriptActionInterface_v1_1 TypeScriptActionInterface v1.1
+    - added @ref TypeScriptActionInterface::JavaScriptInProcessPool "JavaScriptInProcessPool" class for
+      concurrent in-process JavaScript execution without IPC overhead
+      (<a href="https://github.com/qoretechnologies/module-v8/issues/225">issue 225</a>)
+    - added @ref TypeScriptActionInterface::InProcessProgramInfo "InProcessProgramInfo" hashdecl
+    - added @ref TypeScriptActionInterface::TypeScriptActionInterface::startInProcessServerOnDemand()
+      "TypeScriptActionInterface::startInProcessServerOnDemand()" for lazy pool creation with
+      configurable maximum pool size
+    - added @ref TypeScriptActionInterface::TypeScriptActionInterface::setInProcessServer()
+      "TypeScriptActionInterface::setInProcessServer()" for direct pool injection
+    - added @ref TypeScriptActionInterface::TypeScriptActionInterface::checkInProcessServer()
+      "TypeScriptActionInterface::checkInProcessServer()" for pool access with double-checked locking
+    - added @ref TypeScriptActionInterface::TypeScriptActionInterface::shutdownInProcessServer()
+      "TypeScriptActionInterface::shutdownInProcessServer()" for safe pool shutdown
+    - added clone-mode closure capture mechanism using thread-local
+      @ref TypeScriptActionInterfacePriv::Priv::PoolCloneModeHelper "PoolCloneModeHelper" to create
+      pool programs without modifying global state
+    - added static chdir mutex in
+      @ref TypeScriptActionInterface::JavaScriptProgramPool "JavaScriptProgramPool" to prevent
+      concurrent chdir() races during program creation
+
     @subsection TypeScriptActionInterface_v1_0 TypeScriptActionInterface v1.0
     - initial release of the module
 */

--- a/qlib/TypeScriptActionInterface/TypeScriptActionInterfacePriv.qc
+++ b/qlib/TypeScriptActionInterface/TypeScriptActionInterfacePriv.qc
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 #! Qore TypeScriptActionInterface module definition
 
-/*  TypeScriptActionInterfacePriv.qc Copyright 2024 Qore Technologies, s.r.o.
+/*  TypeScriptActionInterfacePriv.qc Copyright 2024 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -201,6 +201,13 @@ function setenv(vr, value) {
         return sprintf("%s/%s", dir, name);
     }
 
+    #! Returns the first available JavaScriptProgramPool from the program store
+    static *JavaScriptProgramPool getFirstPool() {
+        foreach hash<auto> i in (pstore.pairIterator()) {
+            return i.value;
+        }
+    }
+
     static private registerApp(JavaScriptProgram pgm) {
         JavaScriptObject global = pgm.getGlobal();
         if (!global.exports.actionsCatalogue) {
@@ -292,6 +299,37 @@ class DynamicAppContextHelper {
 
     static *bool replacing() {
         return _app_ctx.replace;
+    }
+}
+
+#! Thread-local flag for pool clone mode
+thread_local *bool _pool_clone_mode;
+#! Thread-local storage for closures captured during pool clone mode
+thread_local *hash<string, code> _pool_clone_closures;
+
+#! Helper class for managing pool clone mode
+/** When active, registerAsyncCall() and registerAsyncCallArgs() will capture closures to the thread-local
+    _pool_clone_closures hash instead of modifying global state (acmap).
+*/
+class PoolCloneModeHelper {
+    private {
+        *bool old;
+    }
+
+    constructor() {
+        old = _pool_clone_mode;
+        _pool_clone_mode = True;
+        _pool_clone_closures = {};
+    }
+
+    destructor() {
+        _pool_clone_mode = old;
+        remove _pool_clone_closures;
+    }
+
+    #! Returns the closures captured during clone mode
+    static *hash<string, code> getClosures() {
+        return _pool_clone_closures;
     }
 }
 }

--- a/qlib/TypeScriptActionInterface/TypeScriptActionRecordBasedDataProvider.qc
+++ b/qlib/TypeScriptActionInterface/TypeScriptActionRecordBasedDataProvider.qc
@@ -1,6 +1,6 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
-/*  TypeScriptActionRecordBasedDataProvider.qc Copyright (C) 2023 - 2024 Qore Technologies s.r.o.
+/*  TypeScriptActionRecordBasedDataProvider.qc Copyright (C) 2023 - 2026 Qore Technologies s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -238,7 +238,14 @@ public class TypeScriptActionRecordBasedDataProvider inherits TypeScriptActionDa
             "table": name,
         });
         where_cond = cast<*hash<DataProviderExpression>>(getSearchExpression(where_cond, search_options));
-        if (TSAI::checkServer()) {
+        if (TSAI::checkInProcessServer()) {
+            # in-process pool uses the same path as direct execution
+            *code get_records = getAsyncValue(search_records, cctx,
+                info.expressions ? convertExpression(where_cond) : NOTHING,
+                info.expressions ? search_options : NOTHING);
+            return new TypeScriptBulkRecordInterface(block_size, self, get_records, cctx,
+                info.expressions ? NOTHING : where_cond, search_options);
+        } else if (TSAI::checkServer()) {
             return new TypeScriptBulkRecordProxyInterface(block_size, self, conn.name, conn.getRealOptions(),
                 where_cond, search_options, cctx);
         } else {
@@ -269,7 +276,14 @@ public class TypeScriptActionRecordBasedDataProvider inherits TypeScriptActionDa
             "table": name,
         });
         where_cond = processSearchParameters(where_cond, search_options);
-        if (TSAI::checkServer()) {
+        if (TSAI::checkInProcessServer()) {
+            # in-process pool uses the same path as direct execution
+            *code get_records = getAsyncValue(search_records, cctx,
+                info.expressions ? convertExpression(where_cond) : NOTHING,
+                info.expressions ? search_options : NOTHING);
+            return new TypeScriptBulkRecordInterface(block_size, self, get_records, cctx,
+                info.expressions ? NOTHING : where_cond, search_options);
+        } else if (TSAI::checkServer()) {
             return new TypeScriptBulkRecordProxyInterface(block_size, self, conn.name, conn.getRealOptions(),
                 where_cond, search_options, cctx);
         } else {

--- a/test/example.js
+++ b/test/example.js
@@ -165,6 +165,12 @@ exports.actionsCatalogue = {
                         "account_id": "abc123",
                     };
                 },
+                "connection_update_option": {
+                    "option": "account_id",
+                    "code": async function (ctx) {
+                        return {"account_id": ctx.opt_value};
+                    },
+                },
                 "url_template_options": [
                     "account_id",
                 ],
@@ -764,6 +770,16 @@ exports.actionsCatalogue = {
                         } else {
                             throw new Error('unknown key ' + ctx.opts.key);
                         }
+                    },
+                    "get_dependent_response_options": async function(ctx) {
+                        return {
+                            "resp0": {
+                                "type": "string",
+                                "display_name": "Resp0",
+                                "short_desc": "Response option 0",
+                                "desc": "Response option 0",
+                            },
+                        };
                     },
                 },
                 "dyn": {

--- a/test/js-inprocess-pool.qtest
+++ b/test/js-inprocess-pool.qtest
@@ -164,6 +164,7 @@ async function runWithTimeout(promise, delay) {
         assertEq(first_id, info2.id, "Same thread must get same program without release");
 
         ip.release(info1);
+        ip.release(info2);
     }
 
     #! Test that concurrent threads get different programs and pool grows on demand

--- a/test/js-inprocess-pool.qtest
+++ b/test/js-inprocess-pool.qtest
@@ -1,0 +1,626 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%modern
+
+%requires QUnit
+%requires RestClient
+%requires ../qlib/TypeScriptActionInterface
+%requires v8
+
+%exec-class JavaScriptInProcessPoolTest
+
+public class JavaScriptInProcessPoolTest inherits QUnit::Test {
+    private {
+        Logger logger;
+        #! The test pool created in globalSetUp with proper init callback
+        static JavaScriptProgramPool test_pool;
+    }
+
+    constructor() : Test("JavaScriptInProcessPoolTest", "1.0") {
+        setupLogger();
+
+        addTestCase("pool creation", \poolCreationTest());
+        addTestCase("get and release", \getAndReleaseTest());
+        addTestCase("thread reuse", \threadReuseTest());
+        addTestCase("concurrent access", \concurrentAccessTest());
+        addTestCase("closure mapping", \closureMappingTest());
+        addTestCase("dispatch integration", \dispatchIntegrationTest());
+        addTestCase("error handling", \errorHandlingTest());
+        addTestCase("shutdown safety", \shutdownSafetyTest());
+        addTestCase("bounded pool contention", \boundedPoolContentionTest());
+        addTestCase("sustained contention throughput", \sustainedContentionTest());
+        addTestCase("shutdown under contention", \shutdownUnderContentionTest());
+        addTestCase("on-demand max size", \onDemandMaxSizeTest());
+        addTestCase("shutdown", \shutdownTest());
+
+        # Return for compatibility with test harnesses that check the script's return value
+        set_return_value(main());
+    }
+
+    setupLogger() {
+        LoggerLevel level;
+        if (m_options.verbose > 3) {
+            level = LoggerLevel::getLevelDebug();
+        } else if (m_options.verbose > 2) {
+            level = LoggerLevel::getLevelInfo();
+        } else {
+            level = LoggerLevel::getLevelFatal();
+        }
+        logger = new Logger("console", level);
+        if (m_options.verbose > 2) {
+            logger.addAppender(new StdoutAppender());
+        } else {
+            logger.addAppender(new LoggerAppenderNull());
+        }
+        DataProvider::setGlobalLogger(logger);
+    }
+
+    globalSetUp() {
+        chdir(get_script_dir());
+        # Create pool with a proper init callback that calls registerAppActions
+        # This ensures clone programs also register apps (matching the production pattern)
+        string source = "var exports = {};
+// Returns a Promise that resolves immediately with the state of 'promise'
+function promiseState(promise) {
+  const pendingState = { status: 'pending' };
+  return Promise.race([promise, pendingState]).then(
+    (value) =>
+      value === pendingState ? value : { status: 'fulfilled', value },
+    (reason) => ({ status: 'rejected', reason }),
+  );
+}
+
+async function runWithTimeout(promise, delay) {
+  if (typeof promise === 'function') {
+    promise = promise();
+  }
+  if (!(promise instanceof Promise)) {
+    return promise;
+  }
+
+  // this inspects the state of the promise and returns immediately
+  // without this call, there is an 8-second delay when 'promise' rejects
+  await promiseState(promise);
+
+  // timeout variable to cancel the timeout in case the async function is faster
+  let timeout;
+  // get a promise to a cancelable timeout
+  let top = new Promise((_, reject) => (timeout = setTimeout(() => reject(new Error('Request timed out')), delay)));
+  // run the promise and cancel the timeout
+  return Promise.race([
+    promise,
+    top
+  ]).finally(() => {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  });
+}\n" + File::readTextFile("example.js");
+        test_pool = new JavaScriptProgramPool(source, "example.js",
+            sub (JavaScriptProgram pgm) {
+                JavaScriptObject global = pgm.getGlobal();
+                global.exports.actionsCatalogue.registerAppActions(TypeScriptActionInterface::Api);
+            });
+    }
+
+    globalTearDown() {
+        # ensure in-process server is shut down
+        TypeScriptActionInterface::shutdownInProcessServer();
+        TypeScriptActionInterface::disableInProcessServerOnDemand();
+    }
+
+    #! Returns the test pool for use in tests
+    static JavaScriptProgramPool getTestPool() {
+        return test_pool;
+    }
+
+    #! Test that the pool is created with MinPrograms pre-allocated programs
+    private poolCreationTest() {
+        JavaScriptProgramPool pool = getTestPool();
+        assertTrue(exists pool, "A test JavaScriptProgramPool must be registered");
+
+        JavaScriptInProcessPool ip(pool);
+        assertTrue(exists ip, "In-process pool must be created successfully");
+
+        # verify the pool has a unique hash
+        string hash_val = ip.uniqueHash();
+        assertTrue(hash_val.val(), "Pool unique hash must not be empty");
+        assertTrue(hash_val.find("-inprocess") >= 0, "Pool hash must contain '-inprocess' suffix");
+    }
+
+    #! Test that get() acquires a program and release() returns it to idle
+    private getAndReleaseTest() {
+        JavaScriptProgramPool pool = getTestPool();
+        JavaScriptInProcessPool ip(pool);
+
+        # get a program
+        hash<InProcessProgramInfo> info = ip.get();
+        assertTrue(exists info.pgm, "Program must exist in info");
+        assertTrue(exists info.call_map, "Call map must exist in info");
+        assertTrue(info.id.val(), "Program ID must not be empty");
+        assertEq(gettid(), info.tid, "Program must be assigned to current thread");
+
+        # release and verify we can get again
+        ip.release(info);
+
+        # get again - should get same program back (only one in idle pool)
+        hash<InProcessProgramInfo> info2 = ip.get();
+        assertEq(info.id, info2.id, "Should get same program back after release");
+        ip.release(info2);
+    }
+
+    #! Test that the same thread gets the same program on repeated get() calls
+    private threadReuseTest() {
+        JavaScriptProgramPool pool = getTestPool();
+        JavaScriptInProcessPool ip(pool);
+
+        # first get
+        hash<InProcessProgramInfo> info1 = ip.get();
+        string first_id = info1.id;
+
+        # second get on same thread (without releasing) - should return same program
+        hash<InProcessProgramInfo> info2 = ip.get();
+        assertEq(first_id, info2.id, "Same thread must get same program without release");
+
+        ip.release(info1);
+    }
+
+    #! Test that concurrent threads get different programs and pool grows on demand
+    private concurrentAccessTest() {
+        JavaScriptProgramPool pool = getTestPool();
+        JavaScriptInProcessPool ip(pool);
+
+        int num_threads = 4;
+        Counter start_barrier(1);
+        Counter done_counter(num_threads);
+        Mutex result_mutex();
+        list<string> program_ids = ();
+        list<string> errors = ();
+
+        for (int i = 0; i < num_threads; ++i) {
+            background sub () {
+                try {
+                    # wait for all threads to start
+                    start_barrier.waitForZero();
+
+                    hash<InProcessProgramInfo> info = ip.get();
+                    on_exit ip.release(info);
+
+                    # hold the program for a bit to force other threads to create new ones
+                    usleep(100ms);
+
+                    result_mutex.lock();
+                    on_exit result_mutex.unlock();
+                    program_ids += info.id;
+                } catch (hash<ExceptionInfo> ex) {
+                    result_mutex.lock();
+                    on_exit result_mutex.unlock();
+                    errors += sprintf("%s: %s", ex.err, ex.desc);
+                }
+                done_counter.dec();
+            }();
+        }
+
+        # release all threads at once
+        start_barrier.dec();
+
+        # wait for all threads to complete
+        done_counter.waitForZero();
+
+        assertEq(0, errors.size(), sprintf("No errors expected; got: %y", errors));
+        assertEq(num_threads, program_ids.size(), "Each thread must get a program");
+
+        # verify that at least some threads got different programs (pool grew)
+        hash<string, bool> unique_ids;
+        map (unique_ids{$1} = True), program_ids;
+        assertTrue(unique_ids.size() > 1,
+            sprintf("Pool must grow: expected >1 unique programs, got %d from %y", unique_ids.size(), program_ids));
+    }
+
+    #! Test that the pooled program's call_map has the expected keys
+    /** Verifies that clone mode captures all closure types:
+        - Action-level: api_function, get_dynamic_request_type
+        - Option-level: get_allowed_values, get_element_allowed_values, get_dependent_options,
+          get_dependent_response_options, get_dynamic_type
+        - App-level REST modifiers: post_auth, conn_update
+    */
+    private closureMappingTest() {
+        JavaScriptProgramPool pool = getTestPool();
+        JavaScriptInProcessPool ip(pool);
+
+        hash<InProcessProgramInfo> info = ip.get();
+        on_exit ip.release(info);
+
+        # Action-level closures
+        assertTrue(info.call_map.hasKey("app-js-test-test-api-api_function"),
+            "Pool must have api_function closure");
+        assertTrue(info.call_map.hasKey("app-js-test-test-api-get_dynamic_request_type-api_function"),
+            "Pool must have get_dynamic_request_type closure");
+
+        # Option-level closures
+        assertTrue(info.call_map.hasKey("app-js-test-test-api-count-get_allowed_values"),
+            "Pool must have get_allowed_values closure for 'count' option");
+        assertTrue(info.call_map.hasKey("app-js-test-test-api-other-get_element_allowed_values"),
+            "Pool must have get_element_allowed_values closure for 'other' option");
+        assertTrue(info.call_map.hasKey("app-js-test-test-api-key-get_dependent_options"),
+            "Pool must have get_dependent_options closure for 'key' option");
+        assertTrue(info.call_map.hasKey("app-js-test-test-api-key-get_dependent_response_options"),
+            "Pool must have get_dependent_response_options closure for 'key' option");
+        assertTrue(info.call_map.hasKey("app-js-test-test-api-dyn-get_dynamic_type"),
+            "Pool must have get_dynamic_type closure for 'dyn' option");
+
+        # App-level REST modifier closures
+        assertTrue(info.call_map.hasKey("app-js-test-post_auth"),
+            "Pool must have post_auth closure from rest_modifiers");
+        assertTrue(info.call_map.hasKey("app-js-test-conn_update"),
+            "Pool must have conn_update closure from rest_modifiers");
+
+        # verify all closures are callable
+        int non_callable = 0;
+        foreach hash<auto> i in (info.call_map.pairIterator()) {
+            if (!i.value.callp()) {
+                ++non_callable;
+            }
+        }
+        assertEq(0, non_callable, "All closures in call_map must be callable");
+        assertTrue(info.call_map.size() > 0, "call_map must not be empty");
+    }
+
+    #! Test dispatching calls through the in-process pool via the data provider path
+    private dispatchIntegrationTest() {
+        # initialize the "js-test" app (triggers registerAppIntern which sets up REST options)
+        TypeScriptActionInterface::initApp("js-test");
+
+        # test making an API call through the pool via the data provider
+        hash<auto> config = {
+            "name": "test",
+            "url": "tsrest-js-test://",
+            "opts": {
+                "token": "x",
+            },
+        };
+        TypeScriptAppRestConnection conn(config);
+
+        AbstractDataProvider parent = TypeScriptActionInterface::getDataProvider("js-test", conn);
+        AbstractDataProvider prov = parent.getChildProviderEx("test-api");
+
+        # create in-process pool from test pool and set it as the global in-process server
+        TypeScriptActionInterface::setInProcessServer(new JavaScriptInProcessPool(getTestPool()));
+        on_exit TypeScriptActionInterface::shutdownInProcessServer();
+
+        # get request type (exercises getDynamicDataType through pool)
+        AbstractDataProviderType t = prov.getRequestType();
+        assertTrue(exists t, "Request type must exist");
+        *hash<string, AbstractDataField> fields = t.getFields();
+        assertTrue(exists fields, "Request type must have fields");
+
+        # test concurrent dispatch through the data provider
+        int num_threads = 3;
+        Counter done(num_threads);
+        Mutex result_mutex();
+        list<bool> results = ();
+        list<string> errors = ();
+
+        for (int i = 0; i < num_threads; ++i) {
+            background sub () {
+                try {
+                    AbstractDataProvider tp = TypeScriptActionInterface::getDataProvider("js-test", conn)
+                        .getChildProviderEx("test-api");
+                    AbstractDataProviderType tt = tp.getRequestType();
+                    result_mutex.lock();
+                    on_exit result_mutex.unlock();
+                    results += exists tt;
+                } catch (hash<ExceptionInfo> ex) {
+                    result_mutex.lock();
+                    on_exit result_mutex.unlock();
+                    errors += sprintf("%s: %s", ex.err, ex.desc);
+                }
+                done.dec();
+            }();
+        }
+
+        done.waitForZero();
+        assertEq(0, errors.size(), sprintf("No concurrent dispatch errors expected; got: %y", errors));
+        assertEq(num_threads, results.size(), "All concurrent threads must complete");
+        assertTrue((foldl $1 && $2, results), "All concurrent results must be successful");
+    }
+
+    #! Test error handling for pool operations
+    private errorHandlingTest() {
+        JavaScriptProgramPool pool = getTestPool();
+        JavaScriptInProcessPool ip(pool);
+
+        # test that execCall with a non-existent key throws
+        hash<AsyncCallInfo> bad_api = <AsyncCallInfo>{
+            "key": "nonexistent-key-that-does-not-exist",
+            "label": "test-bad-key",
+            "type": "test",
+            "to": 30s,
+        };
+        assertThrows("POOL-CALL-ERROR", \ip.execCall(), (bad_api,));
+    }
+
+    #! Test shutdown edge cases: get() after shutdown, double shutdown, release() after shutdown
+    private shutdownSafetyTest() {
+        JavaScriptProgramPool pool = getTestPool();
+
+        # get() after shutdown must throw POOL-SHUTDOWN
+        {
+            JavaScriptInProcessPool ip(pool);
+            hash<InProcessProgramInfo> info = ip.get();
+            ip.shutdown();
+            # release after shutdown is a no-op (program already removed from amap)
+            ip.release(info);
+            assertThrows("POOL-SHUTDOWN", \ip.get());
+        }
+
+        # double shutdown must not crash or deadlock
+        {
+            JavaScriptInProcessPool ip(pool);
+            hash<InProcessProgramInfo> info = ip.get();
+            ip.release(info);
+            ip.shutdown();
+            ip.shutdown();
+            # get after double shutdown still throws
+            assertThrows("POOL-SHUTDOWN", \ip.get());
+        }
+    }
+
+    #! Test that a bounded pool (max_size) forces threads to wait and all complete without deadlock
+    private boundedPoolContentionTest() {
+        JavaScriptProgramPool pool = getTestPool();
+        int max_size = 2;
+        int num_threads = 8;
+        JavaScriptInProcessPool ip(pool, max_size);
+
+        Counter start_barrier(1);
+        Counter done_counter(num_threads);
+        Mutex result_mutex();
+        list<string> program_ids = ();
+        list<string> errors = ();
+
+        for (int i = 0; i < num_threads; ++i) {
+            background sub () {
+                try {
+                    start_barrier.waitForZero();
+
+                    hash<InProcessProgramInfo> info = ip.get();
+                    on_exit ip.release(info);
+
+                    # hold the program briefly to force contention
+                    usleep(50ms);
+
+                    result_mutex.lock();
+                    on_exit result_mutex.unlock();
+                    program_ids += info.id;
+                } catch (hash<ExceptionInfo> ex) {
+                    result_mutex.lock();
+                    on_exit result_mutex.unlock();
+                    errors += sprintf("%s: %s", ex.err, ex.desc);
+                }
+                done_counter.dec();
+            }();
+        }
+
+        # release all threads at once
+        start_barrier.dec();
+
+        # all threads must complete (no deadlock) within a reasonable time
+        done_counter.waitForZero();
+
+        assertEq(0, errors.size(), sprintf("No errors expected in bounded pool; got: %y", errors));
+        assertEq(num_threads, program_ids.size(), "All threads must complete in bounded pool");
+
+        # verify pool stayed within bounds: at most max_size unique programs
+        hash<string, bool> unique_ids;
+        map (unique_ids{$1} = True), program_ids;
+        assertTrue(unique_ids.size() <= max_size,
+            sprintf("Pool must not exceed max_size=%d; got %d unique programs: %y",
+                max_size, unique_ids.size(), keys unique_ids));
+        assertTrue(unique_ids.size() > 0, "At least one program must have been used");
+    }
+
+    #! Test sustained acquire/release throughput under contention on a bounded pool
+    private sustainedContentionTest() {
+        JavaScriptProgramPool pool = getTestPool();
+        int max_size = 2;
+        int num_threads = 4;
+        int iterations_per_thread = 20;
+        JavaScriptInProcessPool ip(pool, max_size);
+
+        Counter start_barrier(1);
+        Counter done_counter(num_threads);
+        Mutex result_mutex();
+        list<int> completed_counts = ();
+        list<string> errors = ();
+
+        for (int i = 0; i < num_threads; ++i) {
+            background sub () {
+                int count = 0;
+                try {
+                    start_barrier.waitForZero();
+
+                    for (int j = 0; j < iterations_per_thread; ++j) {
+                        hash<InProcessProgramInfo> info = ip.get();
+                        on_exit ip.release(info);
+
+                        # minimal work to simulate rapid acquire/release cycling
+                        ++count;
+                    }
+                } catch (hash<ExceptionInfo> ex) {
+                    result_mutex.lock();
+                    on_exit result_mutex.unlock();
+                    errors += sprintf("%s: %s (after %d iterations)", ex.err, ex.desc, count);
+                }
+                result_mutex.lock();
+                on_exit result_mutex.unlock();
+                completed_counts += count;
+                done_counter.dec();
+            }();
+        }
+
+        start_barrier.dec();
+        done_counter.waitForZero();
+
+        assertEq(0, errors.size(), sprintf("No errors in sustained contention; got: %y", errors));
+        assertEq(num_threads, completed_counts.size(), "All threads must report completion");
+        int total = (foldl $1 + $2, completed_counts);
+        assertEq(num_threads * iterations_per_thread, total,
+            sprintf("All iterations must complete: expected %d, got %d", num_threads * iterations_per_thread, total));
+    }
+
+    #! Test that shutdown correctly wakes threads waiting for a bounded pool
+    private shutdownUnderContentionTest() {
+        JavaScriptProgramPool pool = getTestPool();
+        int max_size = 1;
+        JavaScriptInProcessPool ip(pool, max_size);
+
+        # acquire the single program so waiting threads will block
+        hash<InProcessProgramInfo> info = ip.get();
+
+        int num_waiting = 3;
+        Counter started(num_waiting);
+        Counter done_counter(num_waiting);
+        Mutex result_mutex();
+        list<string> got_errors = ();
+
+        for (int i = 0; i < num_waiting; ++i) {
+            background sub () {
+                try {
+                    started.dec();
+                    # this will block because the single program is held by the main thread
+                    hash<InProcessProgramInfo> winfo = ip.get();
+                    # if we get here, release it
+                    ip.release(winfo);
+                } catch (hash<ExceptionInfo> ex) {
+                    result_mutex.lock();
+                    on_exit result_mutex.unlock();
+                    got_errors += ex.err;
+                }
+                done_counter.dec();
+            }();
+        }
+
+        # wait for all threads to be started (they'll be blocked in ip.get())
+        started.waitForZero();
+        # give threads time to enter cond.wait()
+        usleep(100ms);
+
+        # call shutdown while our program is still held — all 3 waiters will see
+        # shutdown_flag and throw POOL-SHUTDOWN (if we released first, one waiter
+        # would successfully acquire the program before shutdown runs)
+        ip.shutdown();
+
+        # release our program (no-op after shutdown cleared amap)
+        ip.release(info);
+
+        # all waiting threads must wake up and exit
+        done_counter.waitForZero();
+
+        # all threads should have gotten POOL-SHUTDOWN errors
+        assertEq(num_waiting, got_errors.size(),
+            sprintf("All waiting threads must get errors; got %d of %d", got_errors.size(), num_waiting));
+        foreach string err in (got_errors) {
+            assertEq("POOL-SHUTDOWN", err, "Waiting thread must get POOL-SHUTDOWN on shutdown");
+        }
+    }
+
+    #! Test that startInProcessServerOnDemand() passes max_size to the pool
+    private onDemandMaxSizeTest() {
+        JavaScriptProgramPool pool = getTestPool();
+        int max_size = 2;
+        int num_threads = 4;
+
+        TypeScriptActionInterface::startInProcessServerOnDemand(pool, max_size);
+        on_exit {
+            TypeScriptActionInterface::shutdownInProcessServer();
+            TypeScriptActionInterface::disableInProcessServerOnDemand();
+        }
+
+        # force pool creation via checkInProcessServer
+        *JavaScriptInProcessPool ip = TypeScriptActionInterface::checkInProcessServer();
+        assertTrue(exists ip, "On-demand pool must be created");
+
+        # run concurrent threads to verify max_size is enforced
+        Counter start_barrier(1);
+        Counter done_counter(num_threads);
+        Mutex result_mutex();
+        list<string> program_ids = ();
+        list<string> errors = ();
+
+        for (int i = 0; i < num_threads; ++i) {
+            background sub () {
+                try {
+                    start_barrier.waitForZero();
+                    hash<InProcessProgramInfo> info = ip.get();
+                    on_exit ip.release(info);
+
+                    usleep(50ms);
+
+                    result_mutex.lock();
+                    on_exit result_mutex.unlock();
+                    program_ids += info.id;
+                } catch (hash<ExceptionInfo> ex) {
+                    result_mutex.lock();
+                    on_exit result_mutex.unlock();
+                    errors += sprintf("%s: %s", ex.err, ex.desc);
+                }
+                done_counter.dec();
+            }();
+        }
+
+        start_barrier.dec();
+        done_counter.waitForZero();
+
+        assertEq(0, errors.size(), sprintf("No errors expected; got: %y", errors));
+        assertEq(num_threads, program_ids.size(), "All threads must complete");
+
+        hash<string, bool> unique_ids;
+        map (unique_ids{$1} = True), program_ids;
+        assertTrue(unique_ids.size() <= max_size,
+            sprintf("On-demand pool must respect max_size=%d; got %d unique programs",
+                max_size, unique_ids.size()));
+    }
+
+    #! Test clean shutdown of the pool
+    private shutdownTest() {
+        JavaScriptProgramPool pool = getTestPool();
+
+        {
+            JavaScriptInProcessPool ip(pool);
+
+            # acquire and release a program to ensure the pool is active
+            hash<InProcessProgramInfo> info = ip.get();
+            ip.release(info);
+
+            # pool goes out of scope here - destructor should clean up
+        }
+
+        # test shutdown via TypeScriptActionInterface
+        TypeScriptActionInterface::setInProcessServer(new JavaScriptInProcessPool(pool));
+        *JavaScriptInProcessPool ip = TypeScriptActionInterface::checkInProcessServer();
+        assertTrue(exists ip, "Pool must be available after setInProcessServer");
+
+        TypeScriptActionInterface::shutdownInProcessServer();
+        *JavaScriptInProcessPool ip2 = TypeScriptActionInterface::checkInProcessServer();
+        assertNothing(ip2, "Pool must not be available after shutdown without on-demand");
+
+        # test on-demand behavior (pass test pool for on-demand creation)
+        TypeScriptActionInterface::startInProcessServerOnDemand(pool);
+        on_exit TypeScriptActionInterface::disableInProcessServerOnDemand();
+
+        *JavaScriptInProcessPool ip3 = TypeScriptActionInterface::checkInProcessServer();
+        assertTrue(exists ip3, "Pool must be created on-demand");
+
+        TypeScriptActionInterface::shutdownInProcessServer();
+        *JavaScriptInProcessPool ip4 = TypeScriptActionInterface::checkInProcessServer();
+        assertTrue(exists ip4, "Pool must be re-created since on-demand is still enabled");
+
+        # disable on-demand and verify
+        TypeScriptActionInterface::shutdownInProcessServer();
+        TypeScriptActionInterface::disableInProcessServerOnDemand();
+        *JavaScriptInProcessPool ip5 = TypeScriptActionInterface::checkInProcessServer();
+        assertNothing(ip5, "Pool must not be created after disabling on-demand");
+    }
+}


### PR DESCRIPTION
## Summary

- Add `JavaScriptInProcessPool` class that manages a pool of identical `JavaScriptProgram` instances for concurrent thread access **without IPC overhead** ([issue #225](https://github.com/qoretechnologies/module-v8/issues/225))
- Programs are created on demand when all existing ones are busy, up to a configurable maximum size — threads block when at capacity
- Clone-mode closure capture mechanism uses thread-local `PoolCloneModeHelper` to create pool programs without modifying global `acmap` state
- Dispatch integration: in-process pool is checked first (lowest latency), then out-of-process pool, then single-program direct

### New Classes & APIs
- `JavaScriptInProcessPool` — pool class with `get()`, `release()`, `execCall()`, `shutdown()`
- `InProcessProgramInfo` hashdecl — per-program info with closure map
- `TypeScriptActionInterface::startInProcessServerOnDemand(*pool, *max_size)` — lazy pool creation
- `TypeScriptActionInterface::setInProcessServer(pool)` — direct pool injection
- `TypeScriptActionInterface::checkInProcessServer()` — double-checked locking pool access
- `TypeScriptActionInterface::shutdownInProcessServer()` — safe pool shutdown
- `JavaScriptProgramPool::createProgramForPool()` — clone program with chdir mutex

### Documentation
- `design/in-process-pool.md` — architecture, internals, thread safety
- `docs/mainpage.dox.tmpl` — user-facing docs with 7 usage examples, v2.2 release note
- `TypeScriptActionInterface.qm` — v1.1 release notes

## Test plan
- [x] Pool creation with pre-allocated programs
- [x] Get/release lifecycle and thread reuse
- [x] Concurrent access with on-demand program creation
- [x] Closure mapping for all 9 closure types (API function, table/record functions, REST modifiers, dependent options, dynamic type)
- [x] Dispatch integration via `execCall()`
- [x] Error handling (invalid keys, shutdown during wait)
- [x] Bounded pool contention (8 threads on max_size=2)
- [x] Sustained contention throughput (4 threads x 20 iterations)
- [x] Shutdown under contention (blocked threads wake with POOL-SHUTDOWN)
- [x] On-demand max_size configuration
- [x] Shutdown and on-demand lifecycle
- [x] Valgrind clean (0 bytes lost)
- [x] Regression: existing ts-action-interface and v8 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)