### PR TITLE
Lazy, on-demand app loading for TypeScriptActionInterface

### DIFF
--- a/design/lazy-app-loading.md
+++ b/design/lazy-app-loading.md
@@ -1,0 +1,114 @@
+# Lazy app loading in TypeScriptActionInterface
+
+## Problem
+
+When `TypeScriptActionInterface` is loaded, the master catalogue
+(`ts/dist/index.js` → `ActionsCatalogue`) eagerly `require()`s **all ~100
+apps**, each pulling in its SDK. Measured peak in the `qorus-alpine` image:
+
+- master catalogue (all apps): **~1.9 GB** in the embedded-V8 ts-proxy
+- a single app (Paddle): **~430 MB**
+
+In a memory-constrained CI/k8s pod this OOM-kills the ts-proxy subprocess,
+surfacing to Qorus as a Qore `SOCKET-NOT-OPEN` on the ts-proxy IPC socket
+(see `design/ts-proxy.md`). It also slows every startup that touches one app.
+
+## Key constraint: transparency
+
+The change must be **transparent to API consumers** — `getDataProvider()`,
+`getChildProviderEx()`, the `tsrest-<app>` connection schemes, action schemas
+and `doRequest()` must behave identically. Callers must never have to call
+`initApp()` themselves.
+
+## The existing model already gives us the vehicle
+
+This is the *within-module* continuation of an existing, already-transparent
+**cross-module** lazy model:
+
+1. **Data index** — `qctl update-index` writes `$OMQ_DIR/etc/qore-data-index.yaml`
+   (`ProviderIndexUtil`). It holds, per app, the full browse metadata
+   (`name`, `display_name`, `desc`, `groups`, `scheme: tsrest-<app>`, `logo`,
+   `supports_*`, actions) plus `appmap`/`schememap` (app/scheme → providing
+   `.qmod`).
+2. **Browse is already lazy** — `ProviderIndexUtil::getCachedApps()` /
+   `tryGetAppInfo()` / `tryGetApproximateActionsForApp()` serve the catalogue
+   from the index **with no module loaded**.
+3. **Access is already lazy** — `DataProviderActionCatalog` calls
+   `ProviderIndexUtil::checkAppModule(app)` (and the scheme equivalent) on first
+   touch; that loads the *providing module* and the
+   `registerPendingApp(app, () => initApp(app))` /
+   `registerPendingScheme(...)` closures drive the on-demand init.
+
+So today the laziness stops at the **module** boundary: `checkAppModule("Paddle")`
+loads `TypeScriptActionInterface`, which then loads **all** 100 apps.
+
+## Design: extend the same model one level down
+
+On load, the module registers **every app it provides as pending** (cheap,
+metadata-only) through the *standard* path, and only loads an app's JS+SDK when
+its pending closure fires.
+
+### 1. Lightweight catalogue (done)
+`ActionsCatalogue` no longer statically imports the ~100 apps. It exposes:
+- `loadAppFromPath(api, appDir)` — `require()` one app dir, map it
+  (`processNewApp`) and register its actions on demand.
+- `initializeCatalogue()` only sets up the small custom/existing sets.
+
+Result: the master is now lightweight (it is loaded only to provide
+`loadAppFromPath`).
+
+### 2. Register pending from the index (replaces the manifest)
+There is **no bespoke manifest** — the index is the manifest. On module init,
+when the data index is available:
+- enumerate the module's own `apps/` directories (dir name → `scheme =
+  "tsrest-<dir>"`), cross-reference `ProviderIndexUtil::getCachedApps()` by
+  `scheme` to get the app `name` (+ any metadata needed for the pending stub),
+- register each app pending via the existing primitives:
+  - `appmap{name} = <AppInfo>{app: {name, display_name, …}, pending_path: appDir}`
+  - `ConnectionSchemeCache::registerPendingScheme("tsrest-"+name, () => initApp(name))`
+  - `DataProviderActionCatalog::registerPendingApp(name, () => initApp(name), modulePath)`
+
+These are the exact closures `checkAppModule` already relies on, so catalogue
+drill-in and connection resolution trigger `initApp` with **zero caller
+changes** — that is what makes it transparent.
+
+### 3. On-demand load completes the pending entry
+`initApp(name)` for a pending entry (`AppInfo.pending_path` set) calls
+`TypeScriptActionInterfacePriv::loadAppFromPath(path)` → master
+`actionsCatalogue.loadAppFromPath(Api, path)`. The load re-enters `registerApp`
+with the fully-mapped app; `registerApp` must **complete the existing pending
+entry** (fill in the closures/pool, leave the already-correct pending
+scheme/catalogue in place) rather than throw "already registered" or
+re-register the scheme/catalogue. This is the one careful framework change.
+
+### 4. Dual mode (index build vs runtime)
+- **runtime** (index present for this module): register pending (above).
+- **`qctl update-index` / no index**: fall back to the current full load (load
+  the catalogue and initialize all apps) so the index can be (re)built. The
+  index is built once at image-build time; runtime only reads it.
+
+### 5. Phase 3 — dynamic option values
+Options whose `allowed_values`/`default_value` are functions (e.g.
+`getPaddleProductIdAllowedValues`) can't be served from the index; requesting
+them must trigger `initApp` for that app (cf. the earlier
+`restore eager evaluation of allowed_values` fix). Until then they resolve on
+first init.
+
+## Transparency acceptance test
+
+Against eager and lazy builds, with the module **unloaded**:
+1. browse the catalogue (from the index) — same app list + metadata;
+2. open one app's data provider — only that app loads;
+3. create its `tsrest-<app>` connection — resolves and works;
+4. fetch an action schema and execute it — identical results;
+5. resolve a dynamic `allowed_values` — values returned (lazily).
+None of these require the caller to call `initApp`.
+
+## Measured (prototype, manifest-based precursor)
+
+- register all 100 apps pending: **~110 MB** (all 100 listed)
+- lazy catalogue + load & run Paddle on demand: **590 MB** (vs **1241 MB** all
+  eager) — Paddle executes correctly.
+
+The index-driven version above keeps these numbers while removing the manifest
+and making the path fully transparent via the standard pending primitives.

--- a/design/lazy-app-loading.md
+++ b/design/lazy-app-loading.md
@@ -87,12 +87,15 @@ re-register the scheme/catalogue. This is the one careful framework change.
   the catalogue and initialize all apps) so the index can be (re)built. The
   index is built once at image-build time; runtime only reads it.
 
-### 5. Phase 3 — dynamic option values
+### 5. Phase 3 — dynamic option values (handled by the lazy-init triggers)
 Options whose `allowed_values`/`default_value` are functions (e.g.
-`getPaddleProductIdAllowedValues`) can't be served from the index; requesting
-them must trigger `initApp` for that app (cf. the earlier
-`restore eager evaluation of allowed_values` fix). Until then they resolve on
-first init.
+`getPaddleProductIdAllowedValues`) can't be served from the index. They are
+served by the app's action data provider, which is only reachable through
+`TypeScriptActionRootDataProvider::getChildProviderImpl()` (→ `initApp`) or
+`DataProviderActionCatalog::getAppEx()` (→ `initApp`); both transparently load
+the app on access, after which the dynamic values resolve normally. Verified:
+accessing a pending app's action request type loads only that app and exposes
+the dynamic-allowed-values option. No extra code is required.
 
 ## Transparency acceptance test
 

--- a/qlib/TypeScriptActionInterface/TypeScriptActionInterface.qc
+++ b/qlib/TypeScriptActionInterface/TypeScriptActionInterface.qc
@@ -405,18 +405,28 @@ public class TypeScriptActionInterface {
         falls back to a full load)
     */
     static int registerPendingAppsFromIndex(string apps_dir) {
-        # resolve "tsrest-<dir>" schemes to app info from the data index
-        hash<string, hash<auto>> by_scheme = map {$1.scheme: $1},
-            ProviderIndexUtil::getCachedApps() ?? (), $1.scheme.val();
-        if (!by_scheme) {
+        # Build a map of normalized-key -> app info for tsrest apps in the data index.
+        # The app directory is kebab-case (e.g. "active-campaign") while the
+        # connection scheme is "tsrest-" + app name lower-cased with no separators
+        # (e.g. "tsrest-activecampaign"), so match on a normalized key (lower-case,
+        # alphanumeric only).
+        hash<string, hash<auto>> by_key;
+        foreach hash<auto> ai in (ProviderIndexUtil::getCachedApps() ?? ()) {
+            if (!ai.scheme.val() || !(ai.scheme =~ /^tsrest-/)) {
+                continue;
+            }
+            string suffix = ai.scheme;
+            suffix =~ s/^tsrest-//;
+            by_key{TypeScriptActionInterface::normalizeAppKey(suffix)} = ai;
+        }
+        if (!by_key) {
             return 0;
         }
         int count = 0;
         Dir d();
         d.chdir(apps_dir);
         foreach string dname in (d.listDirs()) {
-            string scheme = "tsrest-" + dname;
-            *hash<auto> info = by_scheme{scheme};
+            *hash<auto> info = by_key{TypeScriptActionInterface::normalizeAppKey(dname)};
             if (!info) {
                 continue;
             }
@@ -435,7 +445,7 @@ public class TypeScriptActionInterface {
                 "pending_path": apps_dir + DirSep + dname,
             };
             appcasemap{appname} = name;
-            ConnectionSchemeCache::registerPendingScheme(scheme, sub () {
+            ConnectionSchemeCache::registerPendingScheme(info.scheme, sub () {
                 TypeScriptActionInterface::initApp(name);
             });
             DataProviderActionCatalog::registerPendingApp(name, sub () {
@@ -444,6 +454,13 @@ public class TypeScriptActionInterface {
             ++count;
         }
         return count;
+    }
+
+    #! Normalizes an app name/scheme fragment to a comparison key (lower-case alphanumeric)
+    static string normalizeAppKey(string s) {
+        s = s.lwr();
+        s =~ s/[^a-z0-9]//g;
+        return s;
     }
 
     #! Sets the server to start on demand

--- a/qlib/TypeScriptActionInterface/TypeScriptActionInterface.qc
+++ b/qlib/TypeScriptActionInterface/TypeScriptActionInterface.qc
@@ -395,18 +395,20 @@ public class TypeScriptActionInterface {
     }
 
     #! Registers the module's apps as pending from the data index, loaded on demand
-    /** Enumerates the app directories under \a apps_dir and, using the data index
-        (ProviderIndexUtil) to resolve each \c "tsrest-<dir>" scheme to its app name,
-        registers each app pending through the standard registerPendingApp() /
-        registerPendingScheme() primitives — exactly the closures the catalogue and
+    /** Reads the generated directory<->app-name map (\c ts-app-dirs.yaml, written next
+        to \a apps_dir by a previous full load) rather than scanning the filesystem,
+        and for each mapped app that the data index (ProviderIndexUtil) exposes as a
+        \c "tsrest-" app, registers it pending through the standard registerPendingApp()
+        / registerPendingScheme() primitives — exactly the closures the catalogue and
         connection layers already use to trigger on-demand init.  The app
         implementation and its SDK are NOT loaded here; each app's JS is loaded from
         its directory only on first use (see initAppIntern()).
 
-        @param apps_dir the directory holding the per-app subdirectories
-        @return the number of apps registered pending (0 if the data index has no
-        matching entries, e.g. while the index is being built — the caller then
-        falls back to a full load)
+        @param apps_dir the directory holding the per-app subdirectories (its parent
+        holds the \c ts-app-dirs.yaml map)
+        @return the number of apps registered pending (0 if the map is missing/empty,
+        e.g. before the index has ever been built — the caller then falls back to a
+        full load)
     */
     static int registerPendingAppsFromIndex(string apps_dir) {
         # The app directory name is not derivable from the app name (e.g. dir

--- a/qlib/TypeScriptActionInterface/TypeScriptActionInterface.qc
+++ b/qlib/TypeScriptActionInterface/TypeScriptActionInterface.qc
@@ -390,30 +390,60 @@ public class TypeScriptActionInterface {
         }, appmap.pairIterator();
     }
 
-    #! Registers apps from a lightweight manifest as pending, loaded on demand
-    /** Each entry must provide: name, display_name, short_desc, desc, and path
-        (the directory holding the app's index.js).  Only metadata is registered
-        here — the app implementation and its SDK are NOT loaded — so the full
-        catalogue is advertised cheaply and each app's JS is loaded from \c path
-        only on first use (see initAppIntern()).
+    #! Registers the module's apps as pending from the data index, loaded on demand
+    /** Enumerates the app directories under \a apps_dir and, using the data index
+        (ProviderIndexUtil) to resolve each \c "tsrest-<dir>" scheme to its app name,
+        registers each app pending through the standard registerPendingApp() /
+        registerPendingScheme() primitives — exactly the closures the catalogue and
+        connection layers already use to trigger on-demand init.  The app
+        implementation and its SDK are NOT loaded here; each app's JS is loaded from
+        its directory only on first use (see initAppIntern()).
+
+        @param apps_dir the directory holding the per-app subdirectories
+        @return the number of apps registered pending (0 if the data index has no
+        matching entries, e.g. while the index is being built — the caller then
+        falls back to a full load)
     */
-    static registerPendingAppFromManifest(list<auto> manifest) {
-        foreach hash<auto> entry in (manifest) {
-            string appname = entry.name.lwr();
-            if (exists appcasemap{appname} || initmap{entry.name}) {
+    static int registerPendingAppsFromIndex(string apps_dir) {
+        # resolve "tsrest-<dir>" schemes to app info from the data index
+        hash<string, hash<auto>> by_scheme = map {$1.scheme: $1},
+            ProviderIndexUtil::getCachedApps() ?? (), $1.scheme.val();
+        if (!by_scheme) {
+            return 0;
+        }
+        int count = 0;
+        Dir d();
+        d.chdir(apps_dir);
+        foreach string dname in (d.listDirs()) {
+            string scheme = "tsrest-" + dname;
+            *hash<auto> info = by_scheme{scheme};
+            if (!info) {
                 continue;
             }
-            appmap{entry.name} = <AppInfo>{
+            string name = info.name;
+            string appname = name.lwr();
+            if (exists appcasemap{appname} || initmap{name}) {
+                continue;
+            }
+            appmap{name} = <AppInfo>{
                 "app": {
-                    "name": entry.name,
-                    "display_name": entry.display_name,
-                    "short_desc": entry.short_desc,
-                    "desc": entry.desc,
+                    "name": name,
+                    "display_name": info.display_name,
+                    "short_desc": info.short_desc,
+                    "desc": info.desc,
                 },
-                "pending_path": entry.path,
+                "pending_path": apps_dir + DirSep + dname,
             };
-            appcasemap{appname} = entry.name;
+            appcasemap{appname} = name;
+            ConnectionSchemeCache::registerPendingScheme(scheme, sub () {
+                TypeScriptActionInterface::initApp(name);
+            });
+            DataProviderActionCatalog::registerPendingApp(name, sub () {
+                TypeScriptActionInterface::initApp(name);
+            }, TypeScriptActionInterface::getModulePath());
+            ++count;
         }
+        return count;
     }
 
     #! Sets the server to start on demand
@@ -723,11 +753,16 @@ public class TypeScriptActionInterface {
                 deregisterDynamicApp(app.name);
             }
             if (exists appcasemap{appname}) {
-                if (IgnoreDuplicateAppHelper::get()) {
+                if (CompletingPendingAppHelper::get()) {
+                    # completing an app registered pending from the index: fall through
+                    # to register the full app; the pending scheme/catalogue already
+                    # exist and are skipped below
+                } else if (IgnoreDuplicateAppHelper::get()) {
                     return;
+                } else {
+                    throw "APP-ERROR", sprintf("App %y has already been registered and is pending "
+                        "initialization", app.name);
                 }
-                throw "APP-ERROR", sprintf("App %y has already been registered and is pending initialization",
-                    app.name);
             }
             if (initmap{app.name}) {
                 if (IgnoreDuplicateAppHelper::get()) {
@@ -898,15 +933,20 @@ public class TypeScriptActionInterface {
 
         appcasemap{appname} = app.name;
 
-        if (app.rest) {
-            string sname = "tsrest-" + appname;
-            ConnectionSchemeCache::registerPendingScheme(sname, sub () {
+        # When completing an app registered pending from the index, the pending
+        # connection scheme + catalogue entry are already in place (pointing at the
+        # same initApp() closure), so do not re-register them.
+        if (!CompletingPendingAppHelper::get()) {
+            if (app.rest) {
+                string sname = "tsrest-" + appname;
+                ConnectionSchemeCache::registerPendingScheme(sname, sub () {
+                    TypeScriptActionInterface::initApp(app.name);
+                });
+            }
+            DataProviderActionCatalog::registerPendingApp(app.name, sub () {
                 TypeScriptActionInterface::initApp(app.name);
-            });
+            }, TypeScriptActionInterface::getModulePath());
         }
-        DataProviderActionCatalog::registerPendingApp(app.name, sub () {
-            TypeScriptActionInterface::initApp(app.name);
-        }, TypeScriptActionInterface::getModulePath());
         TSAI::info("Registered TypeScript app %y -> %y", app.name, app.info);
         TSAI::debug("Registered TypeScript app %y", app.name);
     }
@@ -988,17 +1028,25 @@ public class TypeScriptActionInterface {
         if (initmap{app}) {
             return False;
         }
-        if (*hash<AppInfo> info = remove appmap{app}) {
+        if (*hash<AppInfo> info = appmap{app}) {
             if (info.pending_path) {
-                # lightweight manifest entry: load the real app implementation
-                # (and its SDK) on demand via the master catalogue, then init it.
-                # Drop the case-map stub so the load re-registers the app cleanly.
-                remove appcasemap{app.lwr()};
-                TypeScriptActionInterfacePriv::loadAppFromPath(info.pending_path);
-                return TypeScriptActionInterface::initAppIntern(app, do_actions);
-            } else {
+                # app registered pending from the index: load its implementation (and
+                # SDK) on demand via the master catalogue.  registerApp() runs in
+                # "completing" mode and replaces this pending entry with the full app,
+                # keeping the already-registered pending scheme + catalogue entry.
+                string load_path = info.pending_path;
+                {
+                    CompletingPendingAppHelper cpah();
+                    TypeScriptActionInterfacePriv::loadAppFromPath(load_path);
+                }
+                if (!(info = remove appmap{app})) {
+                    throw "APP-ERROR", sprintf("App %y failed to load its implementation from %y", app,
+                        load_path);
+                }
                 return TypeScriptActionInterface::initAppIntern(info, do_actions);
             }
+            remove appmap{app};
+            return TypeScriptActionInterface::initAppIntern(info, do_actions);
         }
         if (dynamic_path) {
             string fname = sprintf("%s/index.js", dynamic_path);
@@ -3689,7 +3737,7 @@ hashdecl AppInfo {
         display_name, short_desc, desc) and no JS pool/closures; the real app
         implementation (and its SDK) is loaded from this path on demand by
         initAppIntern().  This lets the catalogue register all apps cheaply and
-        only load the ones actually used (see registerPendingAppFromManifest()).
+        only load the ones actually used (see registerPendingAppsFromIndex()).
     */
     *string pending_path;
 

--- a/qlib/TypeScriptActionInterface/TypeScriptActionInterface.qc
+++ b/qlib/TypeScriptActionInterface/TypeScriptActionInterface.qc
@@ -180,6 +180,10 @@ public class TypeScriptActionInterface {
         #! Default post_auth I/O timeout in seconds
         const DefaultPostAuthIoTimeoutSecs = 30;
 
+        #! Name of the directory <-> app-name map file (written next to the app dir during
+        #! a full load; used to register apps pending from the data index at runtime)
+        const AppDirMapFile = "ts-app-dirs.yaml";
+
         #! JavaScript event subtype for connections
         const AES_JS_EVENT = "javascript-event";
 
@@ -405,32 +409,35 @@ public class TypeScriptActionInterface {
         falls back to a full load)
     */
     static int registerPendingAppsFromIndex(string apps_dir) {
-        # Build a map of normalized-key -> app info for tsrest apps in the data index.
-        # The app directory is kebab-case (e.g. "active-campaign") while the
-        # connection scheme is "tsrest-" + app name lower-cased with no separators
-        # (e.g. "tsrest-activecampaign"), so match on a normalized key (lower-case,
-        # alphanumeric only).
-        hash<string, hash<auto>> by_key;
-        foreach hash<auto> ai in (ProviderIndexUtil::getCachedApps() ?? ()) {
-            if (!ai.scheme.val() || !(ai.scheme =~ /^tsrest-/)) {
-                continue;
-            }
-            string suffix = ai.scheme;
-            suffix =~ s/^tsrest-//;
-            by_key{TypeScriptActionInterface::normalizeAppKey(suffix)} = ai;
-        }
-        if (!by_key) {
+        # The app directory name is not derivable from the app name (e.g. dir
+        # "active-directory" -> app "AzureActiveDirectory", "esignature" ->
+        # "DocuSignESignature"), so use the directory <-> app-name map written by a
+        # previous full load (loadAllAppsFromDir, run during `qctl update-index`).
+        string map_file = dirname(apps_dir) + DirSep + AppDirMapFile;
+        if (!is_readable(map_file)) {
             return 0;
         }
+        *hash<auto> dirmap = parse_yaml(File::readTextFile(map_file));
+        if (!dirmap) {
+            return 0;
+        }
+        # index app info keyed by name (tsrest apps only)
+        hash<string, hash<auto>> by_name;
+        foreach hash<auto> ai in (ProviderIndexUtil::getCachedApps() ?? ()) {
+            if (ai.name.val() && ai.scheme.val() && ai.scheme =~ /^tsrest-/) {
+                by_name{ai.name} = ai;
+            }
+        }
         int count = 0;
-        Dir d();
-        d.chdir(apps_dir);
-        foreach string dname in (d.listDirs()) {
-            *hash<auto> info = by_key{TypeScriptActionInterface::normalizeAppKey(dname)};
+        foreach hash<auto> i in (dirmap.pairIterator()) {
+            string dname = i.key;
+            string name = i.value;
+            *hash<auto> info = by_name{name};
             if (!info) {
+                # not a tsrest app in the index (e.g. an "existing" app provided by
+                # another module); skip
                 continue;
             }
-            string name = info.name;
             string appname = name.lwr();
             if (exists appcasemap{appname} || initmap{name}) {
                 continue;
@@ -454,13 +461,6 @@ public class TypeScriptActionInterface {
             ++count;
         }
         return count;
-    }
-
-    #! Normalizes an app name/scheme fragment to a comparison key (lower-case alphanumeric)
-    static string normalizeAppKey(string s) {
-        s = s.lwr();
-        s =~ s/[^a-z0-9]//g;
-        return s;
     }
 
     #! Sets the server to start on demand

--- a/qlib/TypeScriptActionInterface/TypeScriptActionInterface.qc
+++ b/qlib/TypeScriptActionInterface/TypeScriptActionInterface.qc
@@ -390,6 +390,32 @@ public class TypeScriptActionInterface {
         }, appmap.pairIterator();
     }
 
+    #! Registers apps from a lightweight manifest as pending, loaded on demand
+    /** Each entry must provide: name, display_name, short_desc, desc, and path
+        (the directory holding the app's index.js).  Only metadata is registered
+        here — the app implementation and its SDK are NOT loaded — so the full
+        catalogue is advertised cheaply and each app's JS is loaded from \c path
+        only on first use (see initAppIntern()).
+    */
+    static registerPendingAppFromManifest(list<auto> manifest) {
+        foreach hash<auto> entry in (manifest) {
+            string appname = entry.name.lwr();
+            if (exists appcasemap{appname} || initmap{entry.name}) {
+                continue;
+            }
+            appmap{entry.name} = <AppInfo>{
+                "app": {
+                    "name": entry.name,
+                    "display_name": entry.display_name,
+                    "short_desc": entry.short_desc,
+                    "desc": entry.desc,
+                },
+                "pending_path": entry.path,
+            };
+            appcasemap{appname} = entry.name;
+        }
+    }
+
     #! Sets the server to start on demand
     static startServerOnDemand() {
         sm.lock();
@@ -963,7 +989,16 @@ public class TypeScriptActionInterface {
             return False;
         }
         if (*hash<AppInfo> info = remove appmap{app}) {
-            return TypeScriptActionInterface::initAppIntern(info, do_actions);
+            if (info.pending_path) {
+                # lightweight manifest entry: load the real app implementation
+                # (and its SDK) on demand via the master catalogue, then init it.
+                # Drop the case-map stub so the load re-registers the app cleanly.
+                remove appcasemap{app.lwr()};
+                TypeScriptActionInterfacePriv::loadAppFromPath(info.pending_path);
+                return TypeScriptActionInterface::initAppIntern(app, do_actions);
+            } else {
+                return TypeScriptActionInterface::initAppIntern(info, do_actions);
+            }
         }
         if (dynamic_path) {
             string fname = sprintf("%s/index.js", dynamic_path);
@@ -3648,6 +3683,15 @@ hashdecl AppInfo {
 
     #! The current working directory
     string cwd = getcwd();
+
+    #! Lazy-manifest apps: directory holding the app's index.js, loaded on first init
+    /** When set, this AppInfo carries only lightweight manifest metadata (name,
+        display_name, short_desc, desc) and no JS pool/closures; the real app
+        implementation (and its SDK) is loaded from this path on demand by
+        initAppIntern().  This lets the catalogue register all apps cheaply and
+        only load the ones actually used (see registerPendingAppFromManifest()).
+    */
+    *string pending_path;
 
     #! Callback to list tables for the app; required for apps that support record-based actions
     *hash<AsyncCallInfo> get_table_list;

--- a/qlib/TypeScriptActionInterface/TypeScriptActionInterface.qm
+++ b/qlib/TypeScriptActionInterface/TypeScriptActionInterface.qm
@@ -31,6 +31,7 @@
 %requires(reexport) DataProvider
 %requires(reexport) TypeScriptProxy
 %requires ConnectionProvider
+%requires ProviderIndexUtil
 %requires RestClient
 %requires RestClientIo
 %requires Swagger

--- a/qlib/TypeScriptActionInterface/TypeScriptActionInterface.qm
+++ b/qlib/TypeScriptActionInterface/TypeScriptActionInterface.qm
@@ -80,6 +80,14 @@ module TypeScriptActionInterface {
     @section TypeScriptActionInterface_relnotes Release Notes
 
     @subsection TypeScriptActionInterface_v1_1 TypeScriptActionInterface v1.1
+    - added lazy, on-demand app loading: instead of eagerly loading every app (and its SDK) when the
+      module is loaded, apps are registered \a pending from the data provider index and each app's
+      implementation is loaded only on first use (via the catalogue, connection scheme, or data
+      provider tree); this is transparent to API users and significantly reduces the memory used by
+      the @ref TypeScriptProxy "ts-proxy" layer. A directory&lt;-&gt;app-name map (\c ts-app-dirs.yaml)
+      is written next to the app directory during a full load (e.g. \c "qctl update-index") and read at
+      runtime to register apps pending from the index; if it is unavailable the module falls back to a
+      full load
     - added @ref TypeScriptActionInterface::JavaScriptInProcessPool "JavaScriptInProcessPool" class for
       concurrent in-process JavaScript execution without IPC overhead
       (<a href="https://github.com/qoretechnologies/module-v8/issues/225">issue 225</a>)

--- a/qlib/TypeScriptActionInterface/TypeScriptActionInterfacePriv.qc
+++ b/qlib/TypeScriptActionInterface/TypeScriptActionInterfacePriv.qc
@@ -192,14 +192,19 @@ function setenv(vr, value) {
         return global.exports.actionsCatalogue.loadAppFromPath(TypeScriptActionInterface::Api, app_path);
     }
 
-    #! Eagerly load and register every app under the given directory
+    #! Eagerly load and register every curated app under the given directory
     /** Fallback used when the data index / app-dir map is not available (e.g. while
         `qctl update-index` builds the index): the apps cannot be registered pending,
-        so load them all so they can be enumerated/indexed.  Each app is loaded into
-        its own pool and registered fully (scheme + catalogue).  As a side effect the
-        directory <-> app-name map is (re)written next to the app directory so that
-        subsequent runtime starts can register apps pending from the index without
-        loading them (the app directory name is not derivable from the app name).
+        so load them all so they can be enumerated/indexed.  Each curated app (see
+        the catalogue's \c getNewAppDirs()) is loaded through the master catalogue
+        (\c require() in the master program, not a separate pool) and registered with
+        \c registerApp(); any pending action initialization is completed later by
+        @ref TypeScriptActionInterface::TypeScriptActionInterface::initAllApps()
+        "initAllApps()" when \c DPO_DisableOnDemandInitialization is set.  As a side
+        effect the directory <-> app-name map is (re)written next to the app directory
+        so that subsequent runtime starts can register apps pending from the index
+        without loading them (the app directory name is not derivable from the app
+        name).
     */
     static loadAllAppsFromDir(string apps_dir) {
         if (!master) {

--- a/qlib/TypeScriptActionInterface/TypeScriptActionInterfacePriv.qc
+++ b/qlib/TypeScriptActionInterface/TypeScriptActionInterfacePriv.qc
@@ -202,10 +202,16 @@ function setenv(vr, value) {
         loading them (the app directory name is not derivable from the app name).
     */
     static loadAllAppsFromDir(string apps_dir) {
-        Dir d();
-        d.chdir(apps_dir);
+        if (!master) {
+            throw "APP-REGISTRATION-ERROR", "Cannot load apps: no master catalogue is loaded";
+        }
+        # load only the catalogue's curated NEW_APPS directories, not every
+        # subdirectory under apps/ (which can include unrelated or work-in-progress
+        # apps that are deliberately excluded from the catalogue)
+        JavaScriptObject global = master.getProgram().getGlobal();
+        *list<auto> dirs = global.exports.actionsCatalogue.getNewAppDirs();
         hash<string, string> dirmap;
-        foreach string dname in (d.listDirs()) {
+        foreach string dname in (dirs) {
             string app_path = apps_dir + DirSep + dname;
             try {
                 *string name = loadAppFromPath(app_path);

--- a/qlib/TypeScriptActionInterface/TypeScriptActionInterfacePriv.qc
+++ b/qlib/TypeScriptActionInterface/TypeScriptActionInterfacePriv.qc
@@ -160,6 +160,20 @@ function setenv(vr, value) {
         }
     }
 
+    #! Load a manifest-pending app's implementation on demand via the master catalogue
+    /** Used for apps registered pending from the build-time manifest: the master
+        catalogue (now lightweight — it does not eagerly import all apps) loads
+        only the requested app's JS from its directory and registers it.
+    */
+    static loadAppFromPath(string app_path) {
+        if (!master) {
+            throw "APP-REGISTRATION-ERROR", sprintf("Cannot load pending app from %y: no master "
+                "catalogue is loaded", app_path);
+        }
+        JavaScriptObject global = master.getProgram().getGlobal();
+        global.exports.actionsCatalogue.loadAppFromPath(TypeScriptActionInterface::Api, app_path);
+    }
+
      #! Register a dynamic JavaScript file
     static *list<string> processDynamicJavaScriptAppFile(string base_dir, data fdata, *bool replace) {
         if (!master) {

--- a/qlib/TypeScriptActionInterface/TypeScriptActionInterfacePriv.qc
+++ b/qlib/TypeScriptActionInterface/TypeScriptActionInterfacePriv.qc
@@ -115,6 +115,19 @@ function setenv(vr, value) {
                 && (*JavaScriptProgramPool master = createPool(script_path, cwd,
                     \TypeScriptActionInterfacePriv::registerApp()))) {
                 TypeScriptActionInterfacePriv::master = master;
+
+                # Register the module's apps pending from the data index for lazy,
+                # on-demand loading (see design/lazy-app-loading.md).  If the index is
+                # not yet available (e.g. while `qctl update-index` builds it), no apps
+                # are registered here and the DPO_DisableOnDemandInitialization path
+                # below performs a full load instead.
+                string apps_dir = dirname(script_path) + DirSep + "apps";
+                if (is_dir(apps_dir)) {
+                    if (!TypeScriptActionInterface::registerPendingAppsFromIndex(apps_dir)) {
+                        # data index unavailable (e.g. while it is being built): full load
+                        TypeScriptActionInterfacePriv::loadAllAppsFromDir(apps_dir);
+                    }
+                }
             }
 
             *string scripts = ENV.QORE_TYPESCRIPT_ACTION_SCRIPTS;
@@ -160,10 +173,9 @@ function setenv(vr, value) {
         }
     }
 
-    #! Load a manifest-pending app's implementation on demand via the master catalogue
-    /** Used for apps registered pending from the build-time manifest: the master
-        catalogue (now lightweight — it does not eagerly import all apps) loads
-        only the requested app's JS from its directory and registers it.
+    #! Load a single app's implementation on demand via the master catalogue
+    /** The master catalogue (now lightweight — it does not eagerly import all apps)
+        loads only the requested app's JS from its directory and registers it.
     */
     static loadAppFromPath(string app_path) {
         if (!master) {
@@ -172,6 +184,25 @@ function setenv(vr, value) {
         }
         JavaScriptObject global = master.getProgram().getGlobal();
         global.exports.actionsCatalogue.loadAppFromPath(TypeScriptActionInterface::Api, app_path);
+    }
+
+    #! Eagerly load and register every app under the given directory
+    /** Fallback used when the data index is not available (e.g. while
+        `qctl update-index` builds it): the apps cannot be registered pending from
+        the index, so load them all so they can be enumerated/indexed.  Each app is
+        loaded into its own pool and registered fully (scheme + catalogue).
+    */
+    static loadAllAppsFromDir(string apps_dir) {
+        Dir d();
+        d.chdir(apps_dir);
+        foreach string dname in (d.listDirs()) {
+            string app_path = apps_dir + DirSep + dname;
+            try {
+                loadAppFromPath(app_path);
+            } catch (hash<ExceptionInfo> ex) {
+                TSAI::error("Failed to load app from %y: %s: %s", app_path, ex.err, ex.desc);
+            }
+        }
     }
 
      #! Register a dynamic JavaScript file
@@ -277,6 +308,31 @@ class IgnoreDuplicateAppHelper {
 
     static *bool get() {
         return _app_ignore_dup;
+    }
+}
+thread_local *bool _app_completing_pending;
+#! Set while loading the implementation of an app that was registered pending from the index
+/** When set, registerApp() completes the existing pending entry (fills in the app's
+    closures/pool) instead of throwing "already registered" or re-registering the
+    pending connection scheme + catalogue entry, which already point at the correct
+    initApp() closure.  See design/lazy-app-loading.md.
+*/
+class CompletingPendingAppHelper {
+    private {
+        *bool b;
+    }
+
+    constructor() {
+        b = _app_completing_pending;
+        _app_completing_pending = True;
+    }
+
+    destructor() {
+        _app_completing_pending = b;
+    }
+
+    static *bool get() {
+        return _app_completing_pending;
     }
 }
 thread_local *hash<auto> _app_ctx;

--- a/qlib/TypeScriptActionInterface/TypeScriptActionInterfacePriv.qc
+++ b/qlib/TypeScriptActionInterface/TypeScriptActionInterfacePriv.qc
@@ -123,8 +123,13 @@ function setenv(vr, value) {
                 # below performs a full load instead.
                 string apps_dir = dirname(script_path) + DirSep + "apps";
                 if (is_dir(apps_dir)) {
-                    if (!TypeScriptActionInterface::registerPendingAppsFromIndex(apps_dir)) {
-                        # data index unavailable (e.g. while it is being built): full load
+                    # `qctl update-index` turns off on-demand init to enumerate every
+                    # provider; in that mode load all apps so they (incl. any new ones)
+                    # are indexed and the dir map is (re)written.  Otherwise register
+                    # apps pending from the data index; if that yields nothing (no index
+                    # or dir map yet) fall back to a full load.
+                    if ((DataProvider::getOptions() & DPO_DisableOnDemandInitialization)
+                        || !TypeScriptActionInterface::registerPendingAppsFromIndex(apps_dir)) {
                         TypeScriptActionInterfacePriv::loadAllAppsFromDir(apps_dir);
                     }
                 }
@@ -177,30 +182,48 @@ function setenv(vr, value) {
     /** The master catalogue (now lightweight — it does not eagerly import all apps)
         loads only the requested app's JS from its directory and registers it.
     */
-    static loadAppFromPath(string app_path) {
+    static *string loadAppFromPath(string app_path) {
         if (!master) {
             throw "APP-REGISTRATION-ERROR", sprintf("Cannot load pending app from %y: no master "
                 "catalogue is loaded", app_path);
         }
         JavaScriptObject global = master.getProgram().getGlobal();
-        global.exports.actionsCatalogue.loadAppFromPath(TypeScriptActionInterface::Api, app_path);
+        # the JS catalogue returns the loaded app's name
+        return global.exports.actionsCatalogue.loadAppFromPath(TypeScriptActionInterface::Api, app_path);
     }
 
     #! Eagerly load and register every app under the given directory
-    /** Fallback used when the data index is not available (e.g. while
-        `qctl update-index` builds it): the apps cannot be registered pending from
-        the index, so load them all so they can be enumerated/indexed.  Each app is
-        loaded into its own pool and registered fully (scheme + catalogue).
+    /** Fallback used when the data index / app-dir map is not available (e.g. while
+        `qctl update-index` builds the index): the apps cannot be registered pending,
+        so load them all so they can be enumerated/indexed.  Each app is loaded into
+        its own pool and registered fully (scheme + catalogue).  As a side effect the
+        directory <-> app-name map is (re)written next to the app directory so that
+        subsequent runtime starts can register apps pending from the index without
+        loading them (the app directory name is not derivable from the app name).
     */
     static loadAllAppsFromDir(string apps_dir) {
         Dir d();
         d.chdir(apps_dir);
+        hash<string, string> dirmap;
         foreach string dname in (d.listDirs()) {
             string app_path = apps_dir + DirSep + dname;
             try {
-                loadAppFromPath(app_path);
+                *string name = loadAppFromPath(app_path);
+                if (name.val()) {
+                    dirmap{dname} = name;
+                }
             } catch (hash<ExceptionInfo> ex) {
                 TSAI::error("Failed to load app from %y: %s: %s", app_path, ex.err, ex.desc);
+            }
+        }
+        if (dirmap) {
+            string map_file = dirname(apps_dir) + DirSep + TypeScriptActionInterface::AppDirMapFile;
+            try {
+                File f();
+                f.open2(map_file, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+                f.write(make_yaml(dirmap));
+            } catch (hash<ExceptionInfo> ex) {
+                TSAI::error("Failed to write app-dir map %y: %s: %s", map_file, ex.err, ex.desc);
             }
         }
     }

--- a/test/docker_test/test-alpine.sh
+++ b/test/docker_test/test-alpine.sh
@@ -35,6 +35,19 @@ cmake .. -DCMAKE_BUILD_TYPE=debug -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DCMA
 make -j${MAKE_JOBS}
 make install
 
+# build the TypeScript dist from THIS branch so the tests run against the
+# matching catalogue.  The build must be self-contained: do not depend on a
+# pre-built dist from the base image, which may be out of sync with the qlib in
+# this branch.
+echo && echo "-- building TypeScript dist --"
+cd ${MODULE_SRC_DIR}/ts
+corepack enable
+yarn install
+export NODE_OPTIONS="--max-old-space-size=8192"
+yarn build
+echo "export QORE_TYPESCRIPT_MASTER_ACTION_SCRIPT=${MODULE_SRC_DIR}/ts/dist/index.js" >> ${ENV_FILE}
+. ${ENV_FILE}
+
 # add Qore user and group
 if ! grep -q "^qore:x:${QORE_GID}" /etc/group; then
     addgroup -g ${QORE_GID} qore

--- a/test/docker_test/test-ubuntu.sh
+++ b/test/docker_test/test-ubuntu.sh
@@ -34,6 +34,19 @@ cmake .. -DCMAKE_BUILD_TYPE=debug -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}
 make -j${MAKE_JOBS}
 make install
 
+# build the TypeScript dist from THIS branch so the tests run against the
+# matching catalogue.  The build must be self-contained: do not depend on a
+# pre-built dist from the base image, which may be out of sync with the qlib in
+# this branch.
+echo && echo "-- building TypeScript dist --"
+cd ${MODULE_SRC_DIR}/ts
+corepack enable
+yarn install
+export NODE_OPTIONS="--max-old-space-size=8192"
+yarn build
+echo "export QORE_TYPESCRIPT_MASTER_ACTION_SCRIPT=${MODULE_SRC_DIR}/ts/dist/index.js" >> ${ENV_FILE}
+. ${ENV_FILE}
+
 # add Qore user and group
 groupadd -o -g ${QORE_GID} qore
 useradd -o -m -d /home/qore -u ${QORE_UID} -g ${QORE_GID} qore

--- a/ts/src/ActionsCatalogue/index.ts
+++ b/ts/src/ActionsCatalogue/index.ts
@@ -227,11 +227,13 @@ export class ActionsCatalogue {
   }
 
   public initializeCatalogue() {
-    // NEW-style apps are no longer loaded eagerly here: they are registered as
-    // pending from the build-time manifest (see scripts/gen-app-manifest) and
-    // loaded on demand via loadAppFromPath(), so only the apps actually used
-    // are ever parsed/instantiated.  Only the small "custom" and "existing"
-    // app sets are initialized up front.
+    // NEW-style apps are no longer loaded eagerly here.  At runtime they are
+    // registered as pending from the data provider index (resolved through the
+    // generated directory<->app-name map, ts-app-dirs.yaml) and each app's
+    // implementation is loaded on demand via loadAppFromPath(), so only the apps
+    // actually used are ever parsed/instantiated.  Only the small "custom" and
+    // "existing" app sets are initialized up front here; use loadAllNewApps() to
+    // eagerly load the full NEW_APPS set (e.g. for tooling/tests).
     Object.entries(CUSTOM_APPS).forEach(([appName, customApp]) => {
       this.apps[appName] = customApp;
     });
@@ -328,6 +330,25 @@ export class ActionsCatalogue {
   // load exactly the catalogue's apps (and not unrelated/WIP directories).
   public getNewAppDirs(): readonly string[] {
     return NEW_APP_DIRS;
+  }
+
+  /**
+   * Eagerly load and map every NEW_APPS app into `this.apps`, keyed by directory
+   * name. Runtime loads apps lazily on demand via loadAppFromPath(); this is
+   * provided for tooling and tests that need the full catalogue in a Node
+   * context (it is the eager equivalent of the former initializeCatalogue() loop).
+   */
+  public loadAllNewApps(): void {
+    NEW_APP_DIRS.forEach((dir) => {
+      // resolve relative to this module (../apps/<dir>) so the module loader
+      // caches it the same way the former static imports did
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const mod = require(`../apps/${dir}`);
+      const getApp = (mod && (mod.default || mod)) as (
+        locale: Locales
+      ) => TQoreAppWithActions;
+      this.apps[dir] = this.processNewApp(getApp);
+    });
   }
 
   public getOauth2ClientSecret(appName: string): string {

--- a/ts/src/ActionsCatalogue/index.ts
+++ b/ts/src/ActionsCatalogue/index.ts
@@ -12,103 +12,9 @@ import {
 import fs from 'fs';
 import { omit } from 'lodash';
 import path from 'path';
-import activeCampaign from '../apps/active-campaign';
-import activeDirectory from '../apps/active-directory';
-import airtable from '../apps/airtable';
-import amazonCloudfront from '../apps/amazon-cloudfront';
-import amazonCloudWatch from '../apps/amazon-cloudwatch';
-import amazonEc2 from '../apps/amazon-ec2';
-import amazonLambda from '../apps/amazon-lambda';
-import amazonS3 from '../apps/amazon-s3';
-import amazonSes from '../apps/amazon-ses';
-import amazonSns from '../apps/amazon-sns';
-import amazonSqs from '../apps/amazon-sqs';
-import asana from '../apps/asana';
-import attio from '../apps/attio';
-import azureDevops from '../apps/azure-devops';
-import bamboohr from '../apps/bamboohr';
-import baserow from '../apps/baserow';
-import bigml from '../apps/bigml';
-import bitbucket from '../apps/bitbucket';
-import brevo from '../apps/brevo';
-import browserAi from '../apps/browse-ai';
 import businessCentral from '../apps/business-central';
-import calendly from '../apps/calendly';
-import canva from '../apps/canva';
-import clickup from '../apps/clickup';
-import confluence from '../apps/confluence';
-import contentful from '../apps/contentful';
-import coppercrm from '../apps/coppercrm';
-import craft from '../apps/craft';
-import dropbox from '../apps/dropbox';
 import dynamics from '../apps/dynamics';
-import esignature from '../apps/esignature';
-import facebookPages from '../apps/facebook-pages';
-import figma from '../apps/figma';
-import firebase from '../apps/firebase';
-import firestore from '../apps/firestore';
-import freshdesk from '../apps/freshdesk';
-import front from '../apps/front';
-import github from '../apps/github';
-import gitlab from '../apps/gitlab';
-import googleAds from '../apps/google-ads';
-import googleAnalytics from '../apps/google-analytics';
-import googleChat from '../apps/google-chat';
-import googleContacts from '../apps/google-contacts';
-import googleDocs from '../apps/google-docs';
-import googleDrive from '../apps/google-drive';
-import googleForms from '../apps/google-forms';
-import googleMeet from '../apps/google-meet';
-import googleSheets from '../apps/google-sheets';
-import googleTasks from '../apps/google-tasks';
-import helpscout from '../apps/helpscout';
-import hubspot from '../apps/hubspot';
-import intercom from '../apps/intercom';
-import jira from '../apps/jira';
-import klaviyo from '../apps/klaviyo';
-import linkedin from '../apps/linkedin';
-import linkedinOrganizations from '../apps/linkedin-organizations';
-import magento from '../apps/magento';
-import mailchimp from '../apps/mailchimp';
-import mautic from '../apps/mautic';
-import messenger360 from '../apps/messenger360';
-import monday from '../apps/monday';
-import netsuite from '../apps/netsuite';
-import nocodb from '../apps/nocodb';
-import notion from '../apps/notion';
-import odoo from '../apps/odoo';
-import openWeatherMap from '../apps/open-weather-map';
-import openrouter from '../apps/openrouter';
-import outlook from '../apps/outlook';
-import paddle from '../apps/paddle';
-import patreon from '../apps/patreon';
-import paypal from '../apps/paypal';
-import pipedrive from '../apps/pipedrive';
-import pushover from '../apps/pushover';
-import quickbooks from '../apps/quickbooks';
 import salesforce from '../apps/salesforce';
-import seatable from '../apps/seatable';
-import sendgrid from '../apps/sendgrid';
-import sentry from '../apps/sentry';
-import serenity from '../apps/serenity';
-import sharepoint from '../apps/sharepoint';
-import shopify from '../apps/shopify';
-import slack from '../apps/slack';
-import stripe from '../apps/stripe';
-import supabase from '../apps/supabase';
-import surveyMonkey from '../apps/survey-monkey';
-import teams from '../apps/teams';
-import telegram from '../apps/telegram';
-import todoist from '../apps/todoist';
-import trello from '../apps/trello';
-import twilio from '../apps/twilio';
-import typeform from '../apps/typeform';
-import webflow from '../apps/webflow';
-import xero from '../apps/xero';
-import youtube from '../apps/youtube';
-import zendesk from '../apps/zendesk';
-import zohocrm from '../apps/zohocrm';
-import zoom from '../apps/zoom';
 import { Log } from '../decorators/Logger';
 import { mapCrudOptionsToApp, TQoreCrudOptionType } from '../global/helpers';
 import L from '../i18n/i18n-node';
@@ -125,102 +31,7 @@ export interface IQoreApi {
   registerAction: (action: TQoreAppAction) => void;
 }
 
-const NEW_APPS = {
-  activeCampaign,
-  activeDirectory,
-  airtable,
-  amazonEc2,
-  amazonS3,
-  amazonSes,
-  amazonLambda,
-  amazonCloudfront,
-  amazonCloudWatch,
-  amazonSns,
-  amazonSqs,
-  asana,
-  attio,
-  azureDevops,
-  bamboohr,
-  baserow,
-  bigml,
-  bitbucket,
-  brevo,
-  browserAi,
-  calendly,
-  canva,
-  clickup,
-  confluence,
-  contentful,
-  coppercrm,
-  craft,
-  dropbox,
-  esignature,
-  facebookPages,
-  figma,
-  firebase,
-  firestore,
-  freshdesk,
-  github,
-  gitlab,
-  googleAnalytics,
-  googleChat,
-  googleContacts,
-  googleDocs,
-  googleAds,
-  googleDrive,
-  googleForms,
-  googleMeet,
-  googleSheets,
-  googleTasks,
-  helpscout,
-  hubspot,
-  intercom,
-  jira,
-  klaviyo,
-  linkedin,
-  linkedinOrganizations,
-  magento,
-  mailchimp,
-  mautic,
-  messenger360,
-  monday,
-  netsuite,
-  nocodb,
-  notion,
-  odoo,
-  openrouter,
-  openWeatherMap,
-  outlook,
-  paddle,
-  patreon,
-  paypal,
-  pipedrive,
-  pushover,
-  quickbooks,
-  seatable,
-  sendgrid,
-  sentry,
-  serenity,
-  sharepoint,
-  shopify,
-  stripe,
-  supabase,
-  teams,
-  telegram,
-  todoist,
-  trello,
-  twilio,
-  typeform,
-  webflow,
-  xero,
-  youtube,
-  zendesk,
-  zohocrm,
-  zoom,
-  front,
-  slack,
-  surveyMonkey,
-} as const;
+// NEW_APPS are loaded lazily by path on demand (loadAppFromPath); see manifest
 
 const EXISTING_APPS = {
   salesforce,
@@ -316,64 +127,11 @@ export class ActionsCatalogue {
   }
 
   public initializeCatalogue() {
-    Object.entries(NEW_APPS).forEach(
-      ([appName, getApp]: [string, (locale: Locales) => TQoreAppWithActions]) => {
-        const app = getApp(this.locale);
-        const localeGroups = (L[this.locale].apps as any)[app.name]?.groups;
-        const localeConnectionMessage = (L[this.locale].apps as any)[app.name]?.connectionMessage;
-        const connectionMessageTitle = localeConnectionMessage
-          ? localeConnectionMessage.title()
-          : undefined;
-        const connectionMessageContent = localeConnectionMessage
-          ? localeConnectionMessage.content()
-          : undefined;
-
-        const groups = localeGroups
-          ? Object.values(localeGroups).map((fn: any) => fn())
-          : ['Other'];
-
-        const crudOptionTypes: { key: string; localeKey: TQoreCrudOptionType }[] = [
-          { key: 'search_options', localeKey: 'searchOptions' },
-          { key: 'create_options', localeKey: 'createOptions' },
-          { key: 'upsert_options', localeKey: 'upsertOptions' },
-        ];
-
-        const mappedCrudOptions: Record<string, TQoreCrudOptions> = {};
-        for (const { key, localeKey } of crudOptionTypes) {
-          const options = (app as unknown as Record<string, unknown>)[key] as
-            | TQoreCrudOptions
-            | undefined;
-          if (options) {
-            mappedCrudOptions[key] = mapCrudOptionsToApp(
-              app.name as keyof typeof L.en.apps,
-              options,
-              localeKey,
-              this.locale
-            );
-          }
-        }
-
-        this.apps[appName] = {
-          ...app,
-          ...mappedCrudOptions,
-          groups,
-          ...(connectionMessageTitle &&
-            connectionMessageContent && {
-              rest_modifiers: {
-                ...(app.rest_modifiers || {}),
-                messages: [
-                  {
-                    intent: 'info',
-                    title: connectionMessageTitle,
-                    content: connectionMessageContent,
-                  },
-                ],
-              },
-            }),
-        };
-      }
-    );
-
+    // NEW-style apps are no longer loaded eagerly here: they are registered as
+    // pending from the build-time manifest (see scripts/gen-app-manifest) and
+    // loaded on demand via loadAppFromPath(), so only the apps actually used
+    // are ever parsed/instantiated.  Only the small "custom" and "existing"
+    // app sets are initialized up front.
     Object.entries(CUSTOM_APPS).forEach(([appName, customApp]) => {
       this.apps[appName] = customApp;
     });
@@ -381,6 +139,87 @@ export class ActionsCatalogue {
     Object.entries(EXISTING_APPS).forEach(([appName, getApp]) => {
       this.existingApps[appName] = getApp(this.locale);
     });
+  }
+
+  /** Apply locale groups, CRUD options and connection messages to a single
+      NEW-style app (a locale-function export), producing the fully mapped app
+      definition.  Extracted from the former eager initializeCatalogue() loop. */
+  private processNewApp(
+    getApp: (locale: Locales) => TQoreAppWithActions
+  ): TQoreAppWithActions {
+    const app = getApp(this.locale);
+    const localeGroups = (L[this.locale].apps as any)[app.name]?.groups;
+    const localeConnectionMessage = (L[this.locale].apps as any)[app.name]?.connectionMessage;
+    const connectionMessageTitle = localeConnectionMessage
+      ? localeConnectionMessage.title()
+      : undefined;
+    const connectionMessageContent = localeConnectionMessage
+      ? localeConnectionMessage.content()
+      : undefined;
+
+    const groups = localeGroups
+      ? Object.values(localeGroups).map((fn: any) => fn())
+      : ['Other'];
+
+    const crudOptionTypes: { key: string; localeKey: TQoreCrudOptionType }[] = [
+      { key: 'search_options', localeKey: 'searchOptions' },
+      { key: 'create_options', localeKey: 'createOptions' },
+      { key: 'upsert_options', localeKey: 'upsertOptions' },
+    ];
+
+    const mappedCrudOptions: Record<string, TQoreCrudOptions> = {};
+    for (const { key, localeKey } of crudOptionTypes) {
+      const options = (app as unknown as Record<string, unknown>)[key] as
+        | TQoreCrudOptions
+        | undefined;
+      if (options) {
+        mappedCrudOptions[key] = mapCrudOptionsToApp(
+          app.name as keyof typeof L.en.apps,
+          options,
+          localeKey,
+          this.locale
+        );
+      }
+    }
+
+    return {
+      ...app,
+      ...mappedCrudOptions,
+      groups,
+      ...(connectionMessageTitle &&
+        connectionMessageContent && {
+          rest_modifiers: {
+            ...(app.rest_modifiers || {}),
+            messages: [
+              {
+                intent: 'info',
+                title: connectionMessageTitle,
+                content: connectionMessageContent,
+              },
+            ],
+          },
+        }),
+    };
+  }
+
+  /** Load a single NEW-style app from its directory on demand and register its
+      actions.  Called from the Qore side (initApp) for apps that were
+      registered pending from the manifest, so only used apps are ever loaded
+      (and only then is the app's SDK pulled in). */
+  loadAppFromPath(api: IQoreApi, appPath: string) {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const mod = require(appPath);
+    const getApp = mod && (mod.default || mod);
+    if (typeof getApp !== 'function') {
+      throw new Error(`App at ${appPath} does not export a locale function`);
+    }
+    const app = this.processNewApp(getApp);
+    this.apps[app.name] = app;
+    this.registerAppCollection(
+      { [app.name]: app },
+      (a) => api.registerApp(a),
+      (action) => api.registerAction(action)
+    );
   }
 
   public getOauth2ClientSecret(appName: string): string {

--- a/ts/src/ActionsCatalogue/index.ts
+++ b/ts/src/ActionsCatalogue/index.ts
@@ -31,7 +31,107 @@ export interface IQoreApi {
   registerAction: (action: TQoreAppAction) => void;
 }
 
-// NEW_APPS are loaded lazily by path on demand (loadAppFromPath); see manifest
+// Curated list of the app directories that make up NEW_APPS. These apps are
+// loaded lazily by path on demand (loadAppFromPath) instead of being imported
+// eagerly; this list is the lazy equivalent of the former NEW_APPS object and
+// must be kept in sync with it (it deliberately excludes work-in-progress app
+// directories that are not part of the catalogue).
+const NEW_APP_DIRS: readonly string[] = [
+  'active-campaign',
+  'active-directory',
+  'airtable',
+  'amazon-cloudfront',
+  'amazon-cloudwatch',
+  'amazon-ec2',
+  'amazon-lambda',
+  'amazon-s3',
+  'amazon-ses',
+  'amazon-sns',
+  'amazon-sqs',
+  'asana',
+  'attio',
+  'azure-devops',
+  'bamboohr',
+  'baserow',
+  'bigml',
+  'bitbucket',
+  'brevo',
+  'browse-ai',
+  'calendly',
+  'canva',
+  'clickup',
+  'confluence',
+  'contentful',
+  'coppercrm',
+  'craft',
+  'dropbox',
+  'esignature',
+  'facebook-pages',
+  'figma',
+  'firebase',
+  'firestore',
+  'freshdesk',
+  'front',
+  'github',
+  'gitlab',
+  'google-ads',
+  'google-analytics',
+  'google-chat',
+  'google-contacts',
+  'google-docs',
+  'google-drive',
+  'google-forms',
+  'google-meet',
+  'google-sheets',
+  'google-tasks',
+  'helpscout',
+  'hubspot',
+  'intercom',
+  'jira',
+  'klaviyo',
+  'linkedin',
+  'linkedin-organizations',
+  'magento',
+  'mailchimp',
+  'mautic',
+  'messenger360',
+  'monday',
+  'netsuite',
+  'nocodb',
+  'notion',
+  'odoo',
+  'open-weather-map',
+  'openrouter',
+  'outlook',
+  'paddle',
+  'patreon',
+  'paypal',
+  'pipedrive',
+  'pushover',
+  'quickbooks',
+  'seatable',
+  'sendgrid',
+  'sentry',
+  'serenity',
+  'sharepoint',
+  'shopify',
+  'slack',
+  'stripe',
+  'supabase',
+  'survey-monkey',
+  'teams',
+  'telegram',
+  'todoist',
+  'trello',
+  'twilio',
+  'typeform',
+  'webflow',
+  'xero',
+  'youtube',
+  'zendesk',
+  'zohocrm',
+  'zoom',
+];
 
 const EXISTING_APPS = {
   salesforce,
@@ -222,6 +322,12 @@ export class ActionsCatalogue {
     );
     // return the app name so the Qore side can build a dir <-> name map
     return app.name;
+  }
+
+  // Returns the curated list of NEW_APPS directory names so the Qore side can
+  // load exactly the catalogue's apps (and not unrelated/WIP directories).
+  public getNewAppDirs(): readonly string[] {
+    return NEW_APP_DIRS;
   }
 
   public getOauth2ClientSecret(appName: string): string {

--- a/ts/src/ActionsCatalogue/index.ts
+++ b/ts/src/ActionsCatalogue/index.ts
@@ -206,7 +206,7 @@ export class ActionsCatalogue {
       actions.  Called from the Qore side (initApp) for apps that were
       registered pending from the manifest, so only used apps are ever loaded
       (and only then is the app's SDK pulled in). */
-  loadAppFromPath(api: IQoreApi, appPath: string) {
+  loadAppFromPath(api: IQoreApi, appPath: string): string {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const mod = require(appPath);
     const getApp = mod && (mod.default || mod);
@@ -220,6 +220,8 @@ export class ActionsCatalogue {
       (a) => api.registerApp(a),
       (action) => api.registerAction(action)
     );
+    // return the app name so the Qore side can build a dir <-> name map
+    return app.name;
   }
 
   public getOauth2ClientSecret(appName: string): string {

--- a/ts/src/tests/actions-catalogue.test.ts
+++ b/ts/src/tests/actions-catalogue.test.ts
@@ -20,6 +20,9 @@ const collectErrors = (
 describe('Qorus Apps Catalogue tests', () => {
   it('Should register the apps', () => {
     actionsCatalogue.initializeCatalogue();
+    // NEW-style apps load lazily on demand at runtime; eagerly load the full set
+    // here so this test can validate every app's metadata in a Node context.
+    actionsCatalogue.loadAllNewApps();
 
     expect(actionsCatalogue.apps).toHaveProperty('zendesk');
     expect(actionsCatalogue.apps).toHaveProperty('asana');


### PR DESCRIPTION
## Problem

When `TypeScriptActionInterface` loads, the master catalogue eagerly `require()`s **all ~94 apps**, each pulling in its SDK. Measured peak in the embedded-V8 ts-proxy is **~1.9 GB**, vs ~430 MB for a single app. In a memory-constrained CI/k8s pod this OOM-kills the ts-proxy subprocess, surfacing to Qorus as `SOCKET-NOT-OPEN`, and slows every startup that touches one app.

## Approach

Extend the existing **lazy-init / data-index** model one level down — into the module — so on-demand loading is **fully transparent** to `TypeScriptActionInterface` API users (no caller changes):

- **Lightweight catalogue** — `ActionsCatalogue` no longer imports the ~94 apps; `loadAppFromPath()` loads + registers one app on demand (its SDK is pulled in only when used).
- **Register pending from the index** — on load, each app is registered *pending* through the standard `DataProviderActionCatalog::registerPendingApp` / `ConnectionSchemeCache::registerPendingScheme` primitives (the closures the catalogue and connection layers already fire). Browse stays served from `qore-data-index.yaml`; touching an app (catalogue, connection scheme, or data-provider tree) transparently fires `initApp` and loads only that app.
- **Directory↔name map (`ts-app-dirs.yaml`)** — the app dir name isn't derivable from the app name (`active-directory`→`AzureActiveDirectory`, `esignature`→`DocusignESignature`) and the index doesn't record the source dir, so a small map is written next to the app dir during a full load (which runs at `qctl update-index`) and read at runtime.
- **Dual-mode init** — `qctl update-index` (`DPO_DisableOnDemandInitialization`) does a full load so every app is indexed and the map regenerated; normal startup registers pending from the index, falling back to a full load if the index/map is unavailable.
- **Curated app set** — the full load loads exactly the catalogue's `NEW_APPS` dirs (`getNewAppDirs()`), not raw `apps/` enumeration, so WIP/excluded apps and the separately-loaded EXISTING apps aren't pulled in.

Phase 3 (dynamic `allowed_values` that are functions) is handled by the same lazy-init triggers — accessing a pending app's action request type loads only that app and exposes the dynamic option; no extra code needed.

Design doc: `design/lazy-app-loading.md`.

## Results

- **Peak ~585 MB vs ~1241 MB** all-eager (end-to-end with a working app), in the `qorus-alpine` image.
- 95 apps registered pending; touching `Paddle` / `AzureActiveDirectory` loads only that app.
- `qctl update-index` runs clean (94 curated apps, dir-map + index regenerated, 0 errors from the load path).

## Testing

- `test/ts-action-interface.qtest`: 11/11 cases, 127 assertions (`--enable-debug`).
- Validated transparency, `update-index`, and the runtime pending path against the alpine image and the local install.
- No C++ changes (qlib + ts only), so no valgrind needed.

## Packaging / notes

- No qorus dockerfile/script changes required: `ts-app-dirs.yaml` is generated in place by the existing `qctl update-index` step (after the dist is copied to `/opt/qorus/ts-actions`) and carried into the image by the existing `mv /opt /buildroot` + `COPY --from`, exactly like `qore-data-index.yaml`.
- `NEW_APP_DIRS` in the catalogue is the lazy equivalent of `NEW_APPS` and must be kept in sync with it (documented in a comment; a build-time assert could harden this later).

🤖 Generated with [Claude Code](https://claude.com/claude-code)