### PR TITLE
fix(ts-proxy): treat a send-side EPIPE as a command-channel restart condition

### DIFF
--- a/qlib/TypeScriptActionInterface/JavaScriptProgramProxy.qc
+++ b/qlib/TypeScriptActionInterface/JavaScriptProgramProxy.qc
@@ -977,6 +977,21 @@ public class JavaScriptProgramProxy inherits TypeScriptProxy {
                     yaml = makeSend(cmd, {"args": args});
                 }
                 debug("Sending command %y", LoggerUtil::getArgSummary(yaml));
+                @debug {
+                    # TEST: simulate the parent's command send hitting the real Qore Socket::send()
+                    # EPIPE shape (SOCKET-SEND-ERROR / "Broken pipe") that occurs when the child closes
+                    # its end of the command socket mid-send. Unlike TS_PROXY_TEST_FORCE_SOCKET_CLOSE
+                    # (which forces the recv-side SOCKET-NOT-OPEN), this exercises the send-side path;
+                    # fires once, so the retry sends to the restarted child.
+                    if (getenv("TS_PROXY_TEST_FORCE_PARENT_SEND_ERROR").val()) {
+                        unsetenv("TS_PROXY_TEST_FORCE_PARENT_SEND_ERROR");
+                        throw "SOCKET-SEND-ERROR", "error while executing Socket::send(): Broken pipe", EPIPE;
+                    }
+                    # TEST: same but on EVERY attempt (not cleared) - for the bounded-restart test.
+                    if (getenv("TS_PROXY_TEST_FORCE_PARENT_SEND_ERROR_ALWAYS").val()) {
+                        throw "SOCKET-SEND-ERROR", "error while executing Socket::send(): Broken pipe", EPIPE;
+                    }
+                }
                 sendString(yaml);
                 on_exit remove command_in_progress;
                 h = waitForResponse(response_timeout);
@@ -1131,11 +1146,23 @@ public class JavaScriptProgramProxy inherits TypeScriptProxy {
             # Restart the child when it has died, or when the command IPC socket was closed/reset
             # while the child process is still alive.  A broken command channel makes the child
             # unusable for commands, so it must be restarted and the command retried; otherwise the
-            # underlying SOCKET-NOT-OPEN propagates as a fatal error.  This last case is a race:
+            # underlying socket error propagates as a fatal error.  This last case is a race:
             # under load (e.g. the lazy-init first-call latency) the command can sit in
             # waitForResponse long enough for the peer to drop the socket while proc.running() is
             # still true - the qorus-api align-products CI failure.
-            bool socket_dead = ex && ex.err == "SOCKET-NOT-OPEN";
+            #
+            # The break surfaces two ways depending on which side of the channel notices first:
+            #   - recv side (parent blocked in waitForResponse): SOCKET-NOT-OPEN
+            #   - send side (parent's command send races the child's close): the Qore Socket::send()
+            #     EPIPE, i.e. err "SOCKET-SEND-ERROR", desc "...Broken pipe", arg == EPIPE
+            # Both mean the command frame never completed, so both are safe to restart and retry (see
+            # design/ts-proxy.md: "EPIPE or socket-close failures ... should [be treated] as restart
+            # conditions").  Match SOCKET-SEND-ERROR only for EPIPE/broken-pipe (a genuinely dead
+            # peer) - a send timeout is a distinct SOCKET-TIMEOUT error, not this - and deliberately
+            # do NOT widen this to SOCKET-CLOSED: that can occur recv-side after the child has already
+            # executed the command, where a retry could re-run a non-idempotent action.
+            bool socket_dead = ex && (ex.err == "SOCKET-NOT-OPEN"
+                || (ex.err == "SOCKET-SEND-ERROR" && (ex.arg == EPIPE || ex.desc =~ /Broken pipe/i)));
             if (!proc.running() || socket_dead) {
                 string reason = proc.running() ? "command socket closed" : "aborted";
                 if (flags & RF_NO_RESTART) {

--- a/test/ts-proxy.qtest
+++ b/test/ts-proxy.qtest
@@ -23,6 +23,8 @@ public class TsProxyTest inherits QUnit::Test {
         addTestCase("proxy tests", \proxyTests());
         addTestCase("proxy command socket close mid-command", \proxySocketCloseMidCommandTest());
         addTestCase("proxy bounded restart on persistent socket close", \proxyBoundedRestartTest());
+        addTestCase("proxy parent send error mid-command", \proxyParentSendErrorMidCommandTest());
+        addTestCase("proxy parent send error bounded restart", \proxyParentSendErrorBoundedRestartTest());
         addTestCase("proxy restart error handling", \proxyRestartErrorHandlingTest());
         addTestCase("proxy restart wait fast paths", \proxyRestartWaitFastPathTest());
         addTestCase("proxy send error handling", \proxySendErrorHandlingTest());
@@ -237,6 +239,92 @@ public class TsProxyTest inherits QUnit::Test {
         # the command must terminate with a socket error instead of looping forever
         assertTrue(sock_err == "SOCKET-NOT-OPEN" || sock_err == "SOCKET-CLOSED",
             "a command that always breaks the command channel must give up with a socket error, not loop forever");
+        # the number of child restarts must be bounded and deterministic (no timing/polling)
+        assertEq(expected_max_restarts, proxy.getInfo()."restart-count",
+            "the child must be restarted exactly MaxRestarts times before the command gives up");
+    }
+
+    private proxyParentSendErrorMidCommandTest() {
+        skipIfNotReady();
+
+        bool debug_enabled = False;
+        @debug {
+            debug_enabled = True;
+        }
+        if (!debug_enabled) {
+            testSkip("parent-send-error hook requires running with debugging enabled");
+            return;
+        }
+
+        JavaScriptProgramProxy::init(new Mutex());
+        on_exit JavaScriptProgramProxy::shutdown();
+
+        JavaScriptProgramProxy proxy();
+        int pid = proxy.getInfo()."proxy-pid";
+        assertTrue(pid > 0, "proxy should be running for parent-send-error test");
+
+        # The hook makes the parent's command send raise the real Qore Socket::send() EPIPE shape
+        # (SOCKET-SEND-ERROR / "Broken pipe") once - the send-side sibling of the SOCKET-NOT-OPEN
+        # race, which the recv-side hook (proxySocketCloseMidCommandTest) cannot reach. With the fix
+        # the proxy treats it as a dead command channel, restarts the child, and retries the command,
+        # so the call must NOT surface a fatal socket error and the child must have been restarted.
+        setenv("TS_PROXY_TEST_FORCE_PARENT_SEND_ERROR", "1");
+        on_exit unsetenv("TS_PROXY_TEST_FORCE_PARENT_SEND_ERROR");
+
+        *string sock_err;
+        try {
+            proxy.getDynamicOptions("no-such-app", "no-such-action", NOTHING, NOTHING, NOTHING);
+        } catch (hash<ExceptionInfo> ex) {
+            # an app-not-found (or similar) error is acceptable; a socket error is the regression
+            if (ex.err == "SOCKET-SEND-ERROR" || ex.err == "SOCKET-NOT-OPEN" || ex.err == "SOCKET-CLOSED") {
+                sock_err = ex.err;
+            }
+        }
+        assertTrue(!sock_err.val(),
+            "a parent-send EPIPE mid-command must be recovered, not surfaced as a fatal socket error");
+        assertTrue(proxy.getInfo()."proxy-pid" != pid,
+            "child must be restarted after the parent's command send hit EPIPE");
+    }
+
+    private proxyParentSendErrorBoundedRestartTest() {
+        skipIfNotReady();
+
+        bool debug_enabled = False;
+        @debug {
+            debug_enabled = True;
+        }
+        if (!debug_enabled) {
+            testSkip("persistent parent-send-error hook requires running with debugging enabled");
+            return;
+        }
+
+        # this value must match RetryCounter::MaxRestarts in JavaScriptProgramProxy.qc (internal class)
+        int expected_max_restarts = 3;
+
+        JavaScriptProgramProxy::init(new Mutex());
+        on_exit JavaScriptProgramProxy::shutdown();
+
+        JavaScriptProgramProxy proxy();
+        int pid = proxy.getInfo()."proxy-pid";
+        assertTrue(pid > 0, "proxy should be running for parent-send bounded-restart test");
+        assertEq(0, proxy.getInfo()."restart-count", "the child must not have been restarted before the test");
+
+        # Force the parent's command send to raise EPIPE on EVERY attempt. Without the bound the
+        # proxy would restart the child forever; with the fix the command must give up after
+        # RetryCounter::MaxRestarts restarts, terminating with the (send-side) socket error.
+        setenv("TS_PROXY_TEST_FORCE_PARENT_SEND_ERROR_ALWAYS", "1");
+        on_exit unsetenv("TS_PROXY_TEST_FORCE_PARENT_SEND_ERROR_ALWAYS");
+
+        *string sock_err;
+        try {
+            proxy.getDynamicOptions("no-such-app", "no-such-action", NOTHING, NOTHING, NOTHING);
+        } catch (hash<ExceptionInfo> ex) {
+            sock_err = ex.err;
+        }
+
+        # the command must terminate with the socket error instead of looping forever
+        assertEq("SOCKET-SEND-ERROR", sock_err,
+            "a parent send that always breaks must give up with the terminal socket error, not loop forever");
         # the number of child restarts must be bounded and deterministic (no timing/polling)
         assertEq(expected_max_restarts, proxy.getInfo()."restart-count",
             "the child must be restarted exactly MaxRestarts times before the command gives up");


### PR DESCRIPTION
## Summary

When the ts-proxy child closes its end of the command socket while the parent is *sending* a command, Qore's `Socket::send()` raises `err="SOCKET-SEND-ERROR"`, `desc="…Broken pipe"`, `arg == EPIPE`. `checkRestart()`'s `socket_dead` predicate only matched `SOCKET-NOT-OPEN` (the *recv*-side shape), so this send-side break propagated **fatal** to the caller instead of restarting the child and retrying — contrary to `design/ts-proxy.md`: *"EPIPE or socket-close failures … should [be treated] as restart conditions."*

## Fix

Broaden `socket_dead` to also match `SOCKET-SEND-ERROR` when `arg == EPIPE` (or the desc contains "Broken pipe"). Deliberately **narrow**:
- does **not** match other `SOCKET-SEND-ERROR`s (a send timeout is a distinct `SOCKET-TIMEOUT`);
- does **not** widen to `SOCKET-CLOSED`, which can occur recv-side *after* the child has already executed the command, where a retry could re-run a non-idempotent action.

A send-side EPIPE means `sendi8()`/`send()` did not fully transmit the frame, so the child never assembled a complete command and the action never ran — retry is safe. The restart stays bounded by `RetryCounter::MaxRestarts`.

## Why the existing test didn't catch this

`TS_PROXY_TEST_FORCE_SEND_ERROR` throws a **synthetic `SOCKET-CLOSED`** in the *child's response-send* (`bin/ts-proxy`) — the recv-side path, already covered by the `SOCKET-NOT-OPEN` fix. It never makes the **parent's command send** raise the real `SOCKET-SEND-ERROR`, so the production escape had no coverage.

## Testing

Adds a parent-side `@debug` hook (`TS_PROXY_TEST_FORCE_PARENT_SEND_ERROR[_ALWAYS]`) and two tests:
- **mid-command**: a parent-send EPIPE recovers — child restarts (`proxy-pid` changes), command retried, no fatal socket error;
- **bounded restart**: a persistently-broken send gives up after exactly `MaxRestarts` (3) with a terminal `SOCKET-SEND-ERROR`.

`qore -G test/ts-proxy.qtest` → **9/9 cases, 30 assertions** (both new tests pass; existing recv-side tests unchanged).

Refs qoretechnologies/qorus#398
