### PR TITLE
feat: durable delivery checkpoints for TypeScript event triggers

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -385,11 +385,27 @@ jobs:
           # target: four workers at that size use well under a quarter of the 15GB runner.
           NODE_OPTIONS: "--max_old_space_size=4096"
 
-  # Qore toolchain + module-v8 build and its Qore-side tests. Runs in parallel with
-  # unit_tests: none of these steps depend on the jest suites, and previously they sat
-  # behind ~38 minutes of them in the same job.
+  # module-v8's Qore-side build and its Qore tests. Runs in parallel with unit_tests:
+  # none of these steps depend on the jest suites, and previously they sat behind
+  # ~38 minutes of them in the same job.
+  #
+  # The job runs in qore-test-base, the same image GitLab CI uses (see .gitlab-ci.yml).
+  # That image already ships qore develop plus every module this job used to clone and
+  # build for itself -- yaml, uuid, json, process -- together with the node 24 dev files,
+  # LLVM, OpenSSL 3.5 and Arrow it needed to build them. Doing that per run cost ~22 of
+  # the job's ~28 minutes, and caching only ever covered part of it: the OpenSSL-from-
+  # source and apt steps ran even on a cache hit. What is left below is the work that is
+  # actually specific to the pull request.
   qore_tests:
     runs-on: ubuntu-24.04
+    container:
+      image: registry.qoretechnologies.com/infrastructure/qore-test-base/qore-test-base:develop
+      # Read-only (read_registry) deploy token for infrastructure/qore-test-base. Held as
+      # organization secrets, not repository ones: this repository sits at GitHub's limit
+      # of 100 repository secrets, so a 101st is rejected.
+      credentials:
+        username: ${{ secrets.QORE_REGISTRY_USER }}
+        password: ${{ secrets.QORE_REGISTRY_TOKEN }}
     steps:
       - name: Get repo
         uses: actions/checkout@v4
@@ -397,260 +413,31 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      # Required by the "Test catalogue actions" step at the end of this job (yarn test-build)
-      - name: Installing modules
+      # The image keeps its toolchain out of the default environment and in /tmp/env.sh:
+      # qore lives under /opt, node under /opt/nodejs. Every GitHub step runs in a fresh
+      # shell that does not source that file, so publish what the later steps need once.
+      #
+      # QORE_TYPESCRIPT_MASTER_ACTION_SCRIPT is deliberately NOT published: in the image it
+      # points at a TypeScript dist built from develop, and these tests must run against
+      # the dist built from this branch. test-ubuntu.sh rebuilds that dist and repoints the
+      # variable itself, so leaving it unset here keeps the stale one from being picked up.
+      - name: Publish image environment
         run: |
-          cd ts
-          yarn install
+          . /tmp/env.sh
+          printf '%s\n' "${INSTALL_PREFIX}/bin" "${NODEJS_INSTALL_PREFIX}/bin" >> "$GITHUB_PATH"
+          for var in LD_LIBRARY_PATH INSTALL_PREFIX NODE_LIB_DIR NODE_INCLUDE_DIR QORE_MODULE_DIR; do
+            printf '%s=%s\n' "${var}" "${!var}"
+          done >> "$GITHUB_ENV"
 
-      # Install system dependencies needed for building Qore and modules
-      - name: Install dependencies
-        run: |
-          sudo apt update
-          sudo apt install -y \
-            cmake \
-            pkg-config \
-            flex \
-            bison \
-            libmpfr-dev \
-            libpcre3-dev \
-            zlib1g-dev \
-            libbz2-dev \
-            libbrotli-dev \
-            libzstd-dev \
-            liblz4-dev \
-            libkrb5-dev \
-            libutf8proc-dev \
-            libnghttp2-dev \
-            doxygen \
-            libyaml-dev \
-            uuid-dev \
-            libeigen3-dev \
-            libprotobuf-dev \
-            libprotoc-dev \
-            protobuf-compiler \
-            libssh2-1-dev \
-            libssh-dev
-
-      # Install OpenSSL 3.5+ with native QUIC support (SSL_set_quic_tls_cbs)
-      # System OpenSSL 3.0.x lacks QUIC APIs needed by ngtcp2 for Qore's HTTP/3 support
-      # Qore's CI Docker images do the same via /etc/profile.d/quic.sh + OPENSSL_ROOT_DIR
-      - name: Install OpenSSL 3.5
-        run: |
-          # Remove system OpenSSL dev headers to avoid conflicts with OpenSSL 3.5
-          sudo apt-get remove -y libssl-dev 2>/dev/null || true
-          OPENSSL_VERSION="3.5.0"
-          OPENSSL_PREFIX="/opt/openssl-3.5"
-          curl -fsSL "https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz" -o /tmp/openssl.tar.gz
-          cd /tmp && tar xzf openssl.tar.gz
-          cd "/tmp/openssl-${OPENSSL_VERSION}"
-          ./Configure --prefix=${OPENSSL_PREFIX} --libdir=lib no-tests
-          make -j$(nproc)
-          sudo make install_sw
-          echo "${OPENSSL_PREFIX}/lib" | sudo tee /etc/ld.so.conf.d/openssl35.conf
-          sudo ldconfig
-          echo "OPENSSL_ROOT_DIR=${OPENSSL_PREFIX}" >> $GITHUB_ENV
-
-      # Install pre-built Node.js 24 with development headers and libnode.so
-      - name: Install Node.js 24 development files
-        run: |
-          NODEJS_VERSION="24.11.1"
-          NODEJS_INSTALL_PREFIX="/opt/nodejs"
-          NODEJS_ARCH="amd64"
-          NODEJS_TARBALL="nodejs-${NODEJS_VERSION}-ubuntu24.04-${NODEJS_ARCH}.tar.bz2"
-          curl -fsSL -O "https://hq.qoretechnologies.com/~pchalupny/node-builds/${NODEJS_TARBALL}"
-          sudo tar -xjf ${NODEJS_TARBALL} -C /
-          rm -f ${NODEJS_TARBALL}
-          # Create symlink for libnode.so
-          lib=$(ls ${NODEJS_INSTALL_PREFIX}/lib/libnode.so.* | sort | tail -n 1)
-          sudo ln -sf "$(basename "$lib")" ${NODEJS_INSTALL_PREFIX}/lib/libnode.so
-          echo "Node.js 24 dev files installed"
-          ls ${NODEJS_INSTALL_PREFIX}/include/node/v8.h
-
-      # Ubuntu 24.04's default LLVM is 18, which is too old to compile current Qore
-      # develop (its JIT/AOT support tracks newer LLVM releases). Install LLVM 21 — the
-      # version Qore's canonical build-tools/setup-ubuntu.sh uses — from apt.llvm.org and
-      # point CMake at it (find_package(LLVM CONFIG) honours LLVM_DIR / CMAKE_PREFIX_PATH).
-      # Add the repo with curl, not llvm.sh/wget: wget fails SSL verification after the
-      # OpenSSL 3.5 swap above (and llvm.sh uses wget internally). The apt line is http +
-      # gpg-signed (integrity via signed-by), so it sidesteps apt TLS too.
-      - name: Install LLVM 21 for Qore build
-        run: |
-          curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
-            | sudo gpg --dearmor -o /usr/share/keyrings/llvm.gpg
-          echo "deb [signed-by=/usr/share/keyrings/llvm.gpg] http://apt.llvm.org/noble/ llvm-toolchain-noble-21 main" \
-            | sudo tee /etc/apt/sources.list.d/llvm.list
-          sudo apt-get update
-          sudo apt-get install -y llvm-21-dev
-          LLVM_PREFIX=$(ls -d /usr/lib/llvm-* | sort -V | tail -1)
-          echo "Selected LLVM prefix: ${LLVM_PREFIX}"
-          echo "LLVM_DIR=${LLVM_PREFIX}/lib/cmake/llvm" >> "$GITHUB_ENV"
-          echo "CMAKE_PREFIX_PATH=${LLVM_PREFIX}:${CMAKE_PREFIX_PATH}" >> "$GITHUB_ENV"
-
-      # Apache Arrow/Parquet for Qore's in-tree dataframe module (df_parquet.cpp ->
-      # arrow/api.h). Ubuntu 24.04 has no libarrow-dev in apt, so use Apache's repo.
-      # This MUST run after "Install OpenSSL 3.5": libarrow-dev depends on libssl-dev, so
-      # the OpenSSL step's `apt-get remove libssl-dev` cascade-removes Arrow if it was
-      # installed earlier. Installing it last (nothing removes packages after) keeps it.
-      - name: Install Apache Arrow
-        run: |
-          cd /tmp
-          curl -fsSL -o apache-arrow.deb \
-            "https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb"
-          sudo apt-get install -y ./apache-arrow.deb
-          sudo apt-get update
-          sudo apt-get install -y libarrow-dev libparquet-dev
-
-      # Resolve the exact upstream commits this job builds; they form the cache key, so an
-      # unchanged upstream restores the toolchain and a moved one rebuilds it.
-      - name: Resolve upstream build inputs
-        id: build_inputs
-        run: |
-          {
-            echo "qore=$(git ls-remote https://github.com/qoretechnologies/qore.git refs/heads/develop | cut -f1)"
-            for m in yaml uuid json process; do
-              echo "module_${m}=$(git ls-remote https://github.com/qoretechnologies/module-${m}.git HEAD | cut -f1)"
-            done
-          } >> "$GITHUB_OUTPUT"
-
-      # Qore plus the yaml/uuid/json/process modules are installed for real AND staged into
-      # ~/qore-dist via DESTDIR, so a later run with the same upstream commits restores the
-      # whole toolchain with a copy instead of a ~15 minute rebuild. Staging under $HOME
-      # keeps actions/cache away from root-owned paths.
-      - name: Cache Qore toolchain
-        id: qore_cache
-        uses: actions/cache@v4
-        with:
-          path: ~/qore-dist
-          key: qore-dist-ubuntu24-llvm21-${{ steps.build_inputs.outputs.qore }}-${{ steps.build_inputs.outputs.module_yaml }}-${{ steps.build_inputs.outputs.module_uuid }}-${{ steps.build_inputs.outputs.module_json }}-${{ steps.build_inputs.outputs.module_process }}
-
-      # Clone the Qore repository and build it
-      - name: Clone and Build Qore
-        if: steps.qore_cache.outputs.cache-hit != 'true'
-        run: |
-          git clone --branch develop https://github.com/qoretechnologies/qore.git
-          cd qore
-          mkdir build
-          cd build
-          # -DQORE_BUILD_AOT_MODULES=OFF: don't AOT-compile the qlib data-provider qmods.
-          # AOT (added in Qore's 2026-06 JIT/AOT work) requires every wrapped binary module
-          # to be loadable at build time (e.g. MongoDbDataProvider.qmod needs the mongodb
-          # module), but module-v8 doesn't build all optional modules. AOT is a perf-only
-          # optimization we don't need; the qmods still load and run interpreted.
-          V8_INCLUDE_DIR=/opt/nodejs/include/node NODE_LIB_DIR=/opt/nodejs/lib cmake .. -DSINGLE_COMPILATION_UNIT=1 -DCMAKE_BUILD_TYPE=release -DQORE_BUILD_AOT_MODULES=OFF
-          make -j$(nproc)
-          # Stage first, unprivileged: sudo make install writes install_manifest.txt
-          # into the build dir as root, which a later unprivileged install cannot
-          # overwrite (root can overwrite ours, not the other way round).
-          make install DESTDIR="$HOME/qore-dist"
-          sudo make install
-
-      # On a cache hit none of the build steps ran; lay the staged toolchain down over /
-      - name: Restore cached Qore toolchain
-        if: steps.qore_cache.outputs.cache-hit == 'true'
-        run: |
-          sudo cp -a "$HOME/qore-dist/." /
-
-      #  Update library paths to ensure Qore can find its shared libraries
-      - name: Update Library Path
-        run: |
-          echo '/usr/local/lib' | sudo tee /etc/ld.so.conf.d/qore.conf
-          echo '/opt/nodejs/lib' | sudo tee -a /etc/ld.so.conf.d/qore.conf
-          sudo ldconfig
-
-      # Verify Qore installation by checking the version
-      - name: Verify Qore Installation
+      - name: Verify Qore installation
         run: qore --version
 
-      # Clone and build yaml-module
-      - name: Clone and build yaml module
-        if: steps.qore_cache.outputs.cache-hit != 'true'
-        run: |
-          git clone https://github.com/qoretechnologies/module-yaml.git
-          cd module-yaml
-          mkdir build
-          cd build
-          cmake .. -DSINGLE_COMPILATION_UNIT=1 -DCMAKE_BUILD_TYPE=release
-          make
-          make install DESTDIR="$HOME/qore-dist"
-          sudo make install
-
-      # Clone and build uuid-module
-      - name: Clone and build uuid module
-        if: steps.qore_cache.outputs.cache-hit != 'true'
-        run: |
-          git clone https://github.com/qoretechnologies/module-uuid.git
-          cd module-uuid
-          mkdir build
-          cd build
-          cmake .. -DSINGLE_COMPILATION_UNIT=1 -DCMAKE_BUILD_TYPE=release
-          make
-          make install DESTDIR="$HOME/qore-dist"
-          sudo make install
-
-      # Clone and build json-module
-      - name: Clone and build json-module
-        if: steps.qore_cache.outputs.cache-hit != 'true'
-        run: |
-          git clone https://github.com/qoretechnologies/module-json.git
-          cd module-json
-          git submodule update --init
-          mkdir build
-          cd build
-          cmake .. -DSINGLE_COMPILATION_UNIT=1 -DCMAKE_BUILD_TYPE=release
-          make
-          make install DESTDIR="$HOME/qore-dist"
-          sudo make install
-
-      # Clone and build process-module
-      - name: Clone and build process-module
-        if: steps.qore_cache.outputs.cache-hit != 'true'
-        run: |
-          git clone https://github.com/qoretechnologies/module-process.git
-          cd module-process
-          mkdir build
-          cd build
-          cmake .. -DSINGLE_COMPILATION_UNIT=1 -DCMAKE_BUILD_TYPE=release
-          make
-          make install DESTDIR="$HOME/qore-dist"
-          sudo make install
-
-      # Build V8-module
-      - name: Build V8-module
-        run: |
-          git submodule update --init
-          mkdir build
-          cd build
-          NODE_INCLUDE_DIR=/opt/nodejs/include/node NODE_LIB_DIR=/opt/nodejs/lib cmake .. -DSINGLE_COMPILATION_UNIT=1 -DCMAKE_BUILD_TYPE=release
-          make && sudo make install
-
-      # Run module-v8 Qore tests
-      - name: Run module-v8 tests
-        run: |
-          cd test
-          qore --enable-debug v8.qtest -v
-          qore --enable-debug ts-proxy.qtest -v
-          qore --enable-debug ts-action-interface.qtest -v
-
-      # Install RestSchemaDataProvider module (not yet in Qore's CMakeLists.txt)
-      # Ships only in the qore source tree, so stage it into the dist as well — on a cache
-      # hit there is no qore/ checkout to copy it from, it comes back with the toolchain.
-      - name: Install RestSchemaDataProvider module
-        if: steps.qore_cache.outputs.cache-hit != 'true'
-        run: |
-          echo "Installing RestSchemaDataProvider from qore source..."
-          sudo cp -r qore/qlib/RestSchemaDataProvider /usr/local/share/qore-modules/
-          mkdir -p "$HOME/qore-dist/usr/local/share/qore-modules"
-          cp -r qore/qlib/RestSchemaDataProvider "$HOME/qore-dist/usr/local/share/qore-modules/"
-          echo "Verifying installation..."
-          ls -la /usr/local/share/qore-modules/RestSchemaDataProvider/
+      # Builds the module from this branch over the image's copy, rebuilds the TypeScript
+      # dist so the Qore tests exercise this branch's catalogue, and runs every
+      # test/*.qtest as an unprivileged user. This is the script GitLab CI runs, so the two
+      # pipelines share one sequence instead of maintaining two that drift apart.
+      - name: Build and test module-v8
+        run: test/docker_test/test-ubuntu.sh
 
       # Test catalogue actions made with schema
       - name: Test catalogue actions

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -406,6 +406,12 @@ jobs:
       credentials:
         username: ${{ secrets.QORE_REGISTRY_USER }}
         password: ${{ secrets.QORE_REGISTRY_TOKEN }}
+    # A container job defaults to `sh`, not `bash`: GitHub cannot assume bash exists in an
+    # arbitrary image. This one has it, and the steps below want it (indirect expansion in
+    # "Publish image environment" is a bash feature that dash rejects outright).
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Get repo
         uses: actions/checkout@v4

--- a/bin/ts-proxy
+++ b/bin/ts-proxy
@@ -23,6 +23,8 @@ hashdecl EventInfo {
     int waiting;
     #! stop flag
     bool stop_flag = False;
+    #! the checkpoint state handed to the event function, updated as the event function stores new positions
+    auto checkpoint_state;
 }
 
 class TsProxy inherits TypeScriptProxy {
@@ -162,7 +164,7 @@ class TsProxy inherits TypeScriptProxy {
                         break;
 
                     case PC_SETUP_EVENT:
-                        setupEvent(h.args[0], h.args[1], h.args[2], h.args[3]);
+                        setupEvent(h.args[0], h.args[1], h.args[2], h.args[3], h.args[4]);
                         break;
 
                     case PC_RELEASE_EVENT:
@@ -273,7 +275,7 @@ class TsProxy inherits TypeScriptProxy {
         safeSendParent(yaml);
     }
 
-    private setupEvent(string app, string action, string key, *hash<auto> arg0) {
+    private setupEvent(string app, string action, string key, *hash<auto> arg0, auto checkpoint_state) {
         ASSERT(!search);
         TypeScriptActionInterface::initApp(app);
         TypeScriptActionInterface::initAppAction(app, action);
@@ -284,6 +286,7 @@ class TsProxy inherits TypeScriptProxy {
         event = <EventInfo>{
             "key": key,
             "event": TypeScriptActionInterface::getCall(key),
+            "checkpoint_state": checkpoint_state,
         };
         *hash<DataContextInfo> arg;
         if (arg0) {
@@ -355,6 +358,28 @@ class TsProxy inherits TypeScriptProxy {
                 },
                 bool sub () {
                     return event.stop_flag;
+                },
+                {
+                    "get": auto sub () {
+                        return event.checkpoint_state;
+                    },
+                    "set": sub (auto state) {
+                        # values arriving from JavaScript are wrapped; unwrap them before sending
+                        if (state instanceof JavaScriptObject) {
+                            state = cast<JavaScriptObject>(state).toData();
+                        }
+                        string yaml = makeSend(CC_EVENT_CHECKPOINT, {
+                            "key": key,
+                            "state": state,
+                        });
+                        if (!safeSendEvent(event_socket, yaml)) {
+                            event.stop_flag = True;
+                            throw "EVENT-CHECKPOINT-ERROR", sprintf("the event socket for key %y is closed; the "
+                                "checkpoint could not be stored", key);
+                        }
+                        # keep the local copy current so a restart of this event source resumes from here
+                        event.checkpoint_state = state;
+                    },
                 })
             );
             info("Event function for @%s/%s: %s returned", call.app, call.action, call.key);

--- a/qlib/TypeScriptActionInterface/JavaScriptProgramProxy.qc
+++ b/qlib/TypeScriptActionInterface/JavaScriptProgramProxy.qc
@@ -349,9 +349,12 @@ public class JavaScriptProgramProxy inherits TypeScriptProxy {
         }
         info("Setting up event source for PID %d @%s/%s %y", proc.id(), current_event.app, current_event.action,
             current_event.key);
+        # take the checkpoint state from an observer rather than from the value captured at registration, so a
+        # restarted child resumes from the position the previous child reached rather than replaying from startup
+        auto checkpoint_state = current_event.omap.firstValue().getCheckpointState();
         sendCommandArgs(NOTHING, PC_SETUP_EVENT,
-            (current_event.app, current_event.action, current_event.key, current_event.options), NOTHING, True,
-            restart_flags);
+            (current_event.app, current_event.action, current_event.key, current_event.options, checkpoint_state),
+            NOTHING, True, restart_flags);
         info("Event source for @%s/%s %y ready", current_event.app, current_event.action, current_event.key);
     }
 
@@ -481,6 +484,23 @@ public class JavaScriptProgramProxy inherits TypeScriptProxy {
                         info("notify() done for %y", i.key);
                     } catch (hash<ExceptionInfo> ex) {
                         error("Error notifying observer %y for key %y: %s", i.key, v.key, get_exception_string(ex));
+                    }
+                }
+                continue;
+            }
+            if (v.cmd == CC_EVENT_CHECKPOINT) {
+                if (!event.omap) {
+                    error("No observers for event checkpoint for key %y; ignoring", v.key);
+                    continue;
+                }
+                foreach hash<auto> i in (event.omap.pairIterator()) {
+                    try {
+                        i.value.persistEventCheckpoint(v.state);
+                    } catch (hash<ExceptionInfo> ex) {
+                        # the item covered by this checkpoint has already been delivered, so a failed write costs
+                        # re-delivery on the next start, never a lost event
+                        error("Error storing event checkpoint for observer %y for key %y: %s", i.key, v.key,
+                            get_exception_string(ex));
                     }
                 }
                 continue;

--- a/qlib/TypeScriptActionInterface/JavaScriptThreadProcessPool.qc
+++ b/qlib/TypeScriptActionInterface/JavaScriptThreadProcessPool.qc
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 #! Qore TypeScriptActionInterface module definition
 
-/*  JavaScriptThreadProcessPool.qc Copyright 2024 Qore Technologies, s.r.o.
+/*  JavaScriptThreadProcessPool.qc Copyright 2024 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),

--- a/qlib/TypeScriptActionInterface/TypeScriptActionEventDataProvider.qc
+++ b/qlib/TypeScriptActionInterface/TypeScriptActionEventDataProvider.qc
@@ -23,13 +23,49 @@
 
 #! Main module namespace
 public namespace TypeScriptActionInterface {
-public class TypeScriptActionEventDataProvider inherits TypeScriptActionEventDataProviderBase {
+#! Data provider that raises events from a TypeScript event function
+/** The event function owns its own polling loop, so this class does not use the polling machinery in
+    @ref DataProvider::AbstractWatchDataProviderBase "AbstractWatchDataProviderBase"; it inherits that class for the
+    <b>durable checkpoint contract</b>, which lets a TypeScript trigger keep its position in an upstream feed across
+    a host reload.
+
+    @par Checkpoints
+    The event function is called with a fourth argument carrying the checkpoint API:
+    @code{.js}
+event_function: async (ctx, update, should_stop, checkpoint) => {
+    let state = checkpoint.get();               // the state stored by the previous run, if any
+    // ... deliver an item with update(item) ...
+    await checkpoint.set({ cursor: item.id });  // durable once this returns
+}
+    @endcode
+
+    The state is opaque to this class: the event function owns its shape. It is wrapped in a versioned envelope
+    with a monotonic sequence number so that a checkpoint arriving out of order — possible when the event function
+    runs in a separate process and pushes checkpoints over the event socket — cannot move the cursor backwards.
+
+    A checkpoint must only be stored <b>after</b> the item it covers has been delivered with \c update(). Storing
+    it first means a failure loses the item; storing it afterwards means a failure re-delivers it, which is the
+    at-least-once guarantee the checkpoint exists to provide.
+
+    Without a host checkpoint callback configured through
+    @ref DataProvider::AbstractWatchDataProviderBase::setCheckpointPersistence() "setCheckpointPersistence()",
+    \c checkpoint.get() returns @ref nothing and \c checkpoint.set() is a no-op, so an event function written
+    against this API keeps working with in-memory state only.
+*/
+public class TypeScriptActionEventDataProvider inherits TypeScriptActionEventDataProviderBase,
+        DataProvider::AbstractWatchDataProviderBase {
     public {
         #! Provider info
         const ProviderInfo = <DataProviderInfo>{
             "type": "TypeScriptActionEventDataProvider",
             "supports_observable": True,
         };
+
+        #! Placeholder polling interval
+        /** The TypeScript event function owns its own loop, so the base class's polling interval is never used;
+            @ref pollOnce() is likewise never called
+        */
+        const UnusedPollInterval = 60;
     }
 
     private {
@@ -40,14 +76,25 @@ public class TypeScriptActionEventDataProvider inherits TypeScriptActionEventDat
         bool running;
         int waiting;
 
-        #! stop flag
-        bool stop_flag = False;
-
         #! For external processes
         JavaScriptProgramProxy proxy;
 
         #! Event options
         *hash<auto> event_options;
+
+        #! @note the stop flag itself is inherited from @ref DataProvider::AbstractWatchDataProviderBase
+        #! "AbstractWatchDataProviderBase" as \c stop_flag, so that @ref isStopping() reports this provider's state
+
+        #! The checkpoint state restored for the event function, if any
+        auto checkpoint_state;
+
+        #! The sequence number of the last checkpoint accepted
+        /** Guards against a checkpoint arriving out of order over the event socket and moving the cursor backwards
+        */
+        int checkpoint_seq = 0;
+
+        #! Lock protecting the checkpoint state
+        Mutex checkpoint_lock();
     }
 
     #! Creates the object from the arguments
@@ -55,7 +102,8 @@ public class TypeScriptActionEventDataProvider inherits TypeScriptActionEventDat
             *hash<AsyncCallInfo> get_example_event_data, *hash<AsyncCallInfo> get_dynamic_type,
             ActionFunctionContext fctx, hash<AsyncCallInfo> event)
             : TypeScriptActionEventDataProviderBase(name, event_id, event_info, get_example_event_data,
-                get_dynamic_type, fctx) {
+                get_dynamic_type, fctx),
+              AbstractWatchDataProviderBase(UnusedPollInterval) {
         self.event = event;
     }
 
@@ -107,6 +155,88 @@ public class TypeScriptActionEventDataProvider inherits TypeScriptActionEventDat
         return running ?? False;
     }
 
+    #! The ordering of the feed is owned by the TypeScript event function
+    /** The event function decides what it fetches and in what order it delivers, so this class cannot make an
+        ordering claim on its behalf.
+    */
+    string getSourceOrdering() {
+        return WSO_UNKNOWN;
+    }
+
+    #! Never called: the TypeScript event function owns its own polling loop
+    /** @ref observersReady() starts the event function instead of the base class's polling thread, so the base
+        class's loop — and therefore this method — never runs.
+    */
+    private pollOnce() {
+        throw "UNSUPPORTED-OPERATION", sprintf("%y does not use the polling loop of its base class; the "
+            "TypeScript event function owns its own loop", self.className());
+    }
+
+    #! Restores the checkpoint stored by a previous run of the event function
+    /** @param checkpoint the envelope written by @ref persistEventCheckpoint()
+
+        @throw WATCH-CHECKPOINT-ERROR the envelope is not in a recognized format
+    */
+    private restoreCheckpoint(hash<auto> checkpoint) {
+        if (checkpoint.version.typeCode() != NT_INT || checkpoint.version != 1
+                || checkpoint.seq.typeCode() != NT_INT || checkpoint.seq < 0) {
+            throw "WATCH-CHECKPOINT-ERROR", sprintf("invalid TypeScript event checkpoint for %y; expecting version 1 "
+                "and a non-negative seq", getName());
+        }
+        checkpoint_state = checkpoint.state;
+        checkpoint_seq = checkpoint.seq;
+    }
+
+    #! Returns the checkpoint state for the event function, if any
+    /** Also used when an external event source is (re)started, so that a restarted child resumes from the position
+        reached by the previous child rather than from the position restored at startup.
+    */
+    auto getCheckpointState() {
+        AutoLock al(checkpoint_lock);
+        return checkpoint_state;
+    }
+
+    #! Durably stores a checkpoint on behalf of the event function
+    /** @param state the opaque state to store; the event function owns its shape
+
+        @note called both directly (in-process event function) and from the event listener thread when the event
+        function runs in a separate process
+
+        @note the checkpoint lock is held across the host's callback so that the sequence number stays
+        monotonic under concurrent stores; the callback must therefore not call back into this provider
+
+        @throw any exception raised by the host's checkpoint callback, so that an event function awaiting
+        \c checkpoint.set() learns that the position was not made durable
+    */
+    persistEventCheckpoint(auto state) {
+        AutoLock al(checkpoint_lock);
+        int next_seq = checkpoint_seq + 1;
+        # persist before updating the in-memory state: a failed write must not look like a stored position
+        persistCheckpoint({
+            "version": 1,
+            "seq": next_seq,
+            "state": state,
+        });
+        checkpoint_state = state;
+        checkpoint_seq = next_seq;
+    }
+
+    #! Returns the checkpoint API passed to an in-process event function as its fourth argument
+    private hash<auto> getCheckpointApi() {
+        return {
+            "get": auto sub () {
+                return getCheckpointState();
+            },
+            "set": sub (auto state) {
+                # values arriving from JavaScript are wrapped; unwrap them before storing
+                if (state instanceof JavaScriptObject) {
+                    state = cast<JavaScriptObject>(state).toData();
+                }
+                persistEventCheckpoint(state);
+            },
+        };
+    }
+
     #! to notify observers
     notify(hash<auto> event) {
         notifyObservers(event_id, event);
@@ -144,7 +274,7 @@ public class TypeScriptActionEventDataProvider inherits TypeScriptActionEventDat
                 notifyObservers(event_id, event);
             }, bool sub () {
                 return stop_flag;
-            });
+            }, getCheckpointApi());
             info("Event function for @%s/%s: %s returned", event.app, event.action, event.key);
         } catch (hash<ExceptionInfo> ex) {
             error("EVENT-THREAD-ERROR", "Exception in event thread: %s", get_exception_string(ex));

--- a/qlib/TypeScriptProxy/TypeScriptProxy.qc
+++ b/qlib/TypeScriptProxy/TypeScriptProxy.qc
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 #! Qore TypeScriptProxy module definition
 
-/*  TypeScriptProxy.qc Copyright 2024 - 2025 Qore Technologies, s.r.o.
+/*  TypeScriptProxy.qc Copyright 2024 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -93,6 +93,14 @@ public const CC_EVENT_START = "EVENT-START";
 
 #! Child command: "EVENT-TERMINATED"
 public const CC_EVENT_TERMINATED = "EVENT-TERMINATED";
+
+#! Child command: "EVENT-CHECKPOINT"
+/** Sent by the child when an event function stores a delivery checkpoint, so that the parent can make it
+    durable through the host's checkpoint callback.
+
+    @since TypeScriptProxy 1.1
+*/
+public const CC_EVENT_CHECKPOINT = "EVENT-CHECKPOINT";
 
 #! Child command: "STATUS"
 public const CC_STATUS = "STATUS";

--- a/test/example.js
+++ b/test/example.js
@@ -1262,6 +1262,62 @@ exports.actionsCatalogue = {
             },
         });
 
+        api.registerAction({
+            "app": "js-openapi-test",
+            "action": "js-event-checkpoint",
+            "display_name": "JavaScript Checkpoint Event",
+            "short_desc": "JavaScript event action exercising the durable checkpoint API",
+            "desc": "JavaScript event action exercising the durable checkpoint API",
+            "action_code": 1,  // DPAT_EVENT == 1
+            "options": {},
+            /** Exercises the fourth event function argument: the durable checkpoint API.
+
+                Reports the position restored from the previous run, then stores a replacement position, so a
+                test can assert that a checkpoint survives the Qore/JavaScript boundary in both directions.
+            */
+            "event_function": async function(ctx, update, should_stop, checkpoint) {
+                const restored = checkpoint ? checkpoint.get() : undefined;
+                update({
+                    "name": "checkpoint-event",
+                    // report what the previous run left behind, so the test can assert restoration
+                    "code": restored && restored.cursor ? restored.cursor : 0,
+                });
+                if (checkpoint) {
+                    // stored only after the event has been raised: a position stored first would be a
+                    // position for an event that may never have been delivered
+                    await checkpoint.set({"cursor": (restored && restored.cursor ? restored.cursor : 0) + 1});
+                }
+                // returns once the position has been stored: update() delivers synchronously, so there is
+                // nothing left to wait for, and looping here would only tie up the JavaScript thread
+            },
+            "event_info": {
+                "desc": "Checkpoint event",
+                "type": {
+                    "type": "hash",
+                    "fields": {
+                        "name": {
+                            "type": "string",
+                            "display_name": "Event Name",
+                            "short_desc": "Event name",
+                            "desc": "Event name",
+                        },
+                        "code": {
+                            "type": "int",
+                            "display_name": "Restored Cursor",
+                            "short_desc": "The cursor restored from the previous run",
+                            "desc": "The cursor restored from the previous run",
+                        },
+                    },
+                },
+            },
+            "get_example_event_data": async function (ctx) {
+                return {
+                    "name": "checkpoint-event",
+                    "code": 0,
+                };
+            },
+        });
+
         // OpenAPI 3.0 test app
         api.registerApp({
             "name": "js-openapi3-test",

--- a/test/ts-action-interface.qtest
+++ b/test/ts-action-interface.qtest
@@ -33,6 +33,8 @@ public class TypeScriptActionInterfaceTest inherits QUnit::Test {
 
         addTestCase("js event extension", \jsEventExtensionTest());
         addTestCase("js events", \jsEventTest());
+        addTestCase("event checkpoints", \eventCheckpointTest());
+        addTestCase("event checkpoint validation", \eventCheckpointValidationTest());
         addTestCase("webhook events", \webhookEventTest());
         addTestCase("webhook format_event_data transform", \webhookFormatEventDataTransformTest());
         addTestCase("webhook format_event_data filter", \webhookFormatEventDataFilterTest());
@@ -153,6 +155,93 @@ async function runWithTimeout(promise, delay) {
                 "code": 1234,
             },
         }, event);
+    }
+
+    #! A TypeScript event function must be able to keep a durable position across a reload
+    /** The whole point of a checkpoint is that the position survives the host restarting the provider. This
+        drives the real Qore/JavaScript boundary in both directions: the state restored into the provider must
+        reach \c checkpoint.get() in JavaScript, and the state passed to \c checkpoint.set() must reach the
+        host's storage callback.
+    */
+    private eventCheckpointTest() {
+        hash<auto> config = {
+            "name": "test",
+            "url": "tsrest-js-openapi-test://",
+            "opts": {
+                "subdomain": "test",
+                "token": "x",
+            },
+        };
+        TypeScriptAppRestConnection conn(config);
+
+        list<hash<auto>> saved = ();
+        AbstractDataProvider prov =
+            TypeScriptActionInterface::getDataProvider("js-openapi-test", conn)
+                .getChildProviderEx("js-event-checkpoint");
+
+        # a fresh provider has nothing to restore, so the event function reports cursor 0
+        MyObserver o();
+        cast<Observable>(prov).registerObserver(o);
+        cast<AbstractWatchDataProviderBase>(prov).setCheckpointPersistence(NOTHING,
+            sub (hash<auto> checkpoint) {
+                saved += checkpoint;
+            });
+        cast<DelayedObservable>(prov).observersReady();
+        on_exit cast<DelayedObservable>(prov).stopEvents();
+
+        hash<auto> event = o.waitForEvent();
+        assertEq("checkpoint-event", event.data.name);
+        assertEq(0, event.data.code, "nothing was restored on a first start");
+
+        # the position stored by the event function reached the host callback, in a versioned envelope
+        assertEq(1, saved.size(), "the event function's checkpoint reached the host");
+        assertEq(1, saved[0].version, "the checkpoint is versioned");
+        assertEq(1, saved[0].seq, "the first checkpoint carries sequence 1");
+        assertEq({"cursor": 1}, saved[0].state, "the state the event function stored round-tripped intact");
+
+        # a replacement provider given that checkpoint must resume from it rather than start over
+        AbstractDataProvider prov2 =
+            TypeScriptActionInterface::getDataProvider("js-openapi-test", conn)
+                .getChildProviderEx("js-event-checkpoint");
+        list<hash<auto>> saved2 = ();
+        MyObserver o2();
+        cast<Observable>(prov2).registerObserver(o2);
+        cast<AbstractWatchDataProviderBase>(prov2).setCheckpointPersistence(saved[0],
+            sub (hash<auto> checkpoint) {
+                saved2 += checkpoint;
+            });
+        cast<DelayedObservable>(prov2).observersReady();
+        on_exit cast<DelayedObservable>(prov2).stopEvents();
+
+        hash<auto> event2 = o2.waitForEvent();
+        assertEq(1, event2.data.code, "the stored position was restored into the event function");
+        assertEq({"cursor": 2}, saved2[0].state, "the resumed run advanced from the restored position");
+        assertEq(2, saved2[0].seq, "the sequence number advances with the restored checkpoint");
+    }
+
+    #! A checkpoint envelope in an unknown shape must be rejected rather than silently ignored
+    private eventCheckpointValidationTest() {
+        hash<auto> config = {
+            "name": "test",
+            "url": "tsrest-js-openapi-test://",
+            "opts": {
+                "subdomain": "test",
+                "token": "x",
+            },
+        };
+        TypeScriptAppRestConnection conn(config);
+        AbstractDataProvider prov =
+            TypeScriptActionInterface::getDataProvider("js-openapi-test", conn)
+                .getChildProviderEx("js-event-checkpoint");
+
+        assertThrows("WATCH-CHECKPOINT-ERROR", "version 1", sub () {
+            cast<AbstractWatchDataProviderBase>(prov).setCheckpointPersistence({"version": 2, "seq": 1},
+                sub (hash<auto> checkpoint) {});
+        });
+        assertThrows("WATCH-CHECKPOINT-ERROR", "non-negative seq", sub () {
+            cast<AbstractWatchDataProviderBase>(prov).setCheckpointPersistence({"version": 1, "seq": -1},
+                sub (hash<auto> checkpoint) {});
+        });
     }
 
     private jsEventTest() {

--- a/ts/src/ActionsCatalogue/index.ts
+++ b/ts/src/ActionsCatalogue/index.ts
@@ -181,7 +181,7 @@ if (process.env.CUSTOM_APPS_DIR) {
  * @param action - the action being registered.
  * @returns the action, with its event function wrapped when it has one.
  */
-const withCheckpointSupport = (action: TQoreAppAction): TQoreAppAction => {
+export const withCheckpointSupport = (action: TQoreAppAction): TQoreAppAction => {
   if (!('event_function' in action) || typeof action.event_function !== 'function') {
     return action;
   }
@@ -190,14 +190,17 @@ const withCheckpointSupport = (action: TQoreAppAction): TQoreAppAction => {
 
   return {
     ...action,
+    // the original's return value is propagated: an async event function returns a promise that the
+    // Qore side awaits, so discarding it here would let the host treat the function as already
+    // finished and would swallow a rejection
     event_function: (
       context: Parameters<typeof event_function>[0],
       update: Parameters<typeof event_function>[1],
       should_stop: Parameters<typeof event_function>[2],
       checkpoint: unknown
-    ) =>
+    ): unknown =>
       runWithTriggerCheckpoint(isTriggerCheckpoint(checkpoint) ? checkpoint : undefined, () =>
-        (event_function as (...args: unknown[]) => void)(context, update, should_stop, checkpoint)
+        (event_function as (...args: unknown[]) => unknown)(context, update, should_stop, checkpoint)
       ),
   } as TQoreAppAction;
 };

--- a/ts/src/ActionsCatalogue/index.ts
+++ b/ts/src/ActionsCatalogue/index.ts
@@ -19,6 +19,10 @@ import { Log } from '../decorators/Logger';
 import { mapCrudOptionsToApp, TQoreCrudOptionType } from '../global/helpers';
 import L from '../i18n/i18n-node';
 import { Locales } from '../i18n/i18n-types';
+import {
+  isTriggerCheckpoint,
+  runWithTriggerCheckpoint,
+} from '../global/helpers/trigger-checkpoint';
 import { Debugger, DebugLevels } from '../utils/Debugger';
 
 if (process.env.TS_DEBUG) {
@@ -162,6 +166,42 @@ if (process.env.CUSTOM_APPS_DIR) {
   importIndexFilesFromDir(path.resolve(process.env.CUSTOM_APPS_DIR));
 }
 
+/**
+ * Publishes the host's durable checkpoint API to an action's event function.
+ *
+ * Qore calls an event function with `(context, update, should_stop, checkpoint)`. Threading that fourth
+ * argument through every trigger and on into its polling helper would mean touching every trigger for a
+ * concern none of them expresses directly, so it is published here instead: the event function still runs
+ * with its own signature, and `getTriggerCheckpoint()` resolves the API for whatever polling helper it
+ * calls, however deep the async call stack goes.
+ *
+ * The original function is also called with the checkpoint as its fourth argument, so a trigger that wants
+ * to drive the cursor itself can simply declare the parameter.
+ *
+ * @param action - the action being registered.
+ * @returns the action, with its event function wrapped when it has one.
+ */
+const withCheckpointSupport = (action: TQoreAppAction): TQoreAppAction => {
+  if (!('event_function' in action) || typeof action.event_function !== 'function') {
+    return action;
+  }
+
+  const { event_function } = action;
+
+  return {
+    ...action,
+    event_function: (
+      context: Parameters<typeof event_function>[0],
+      update: Parameters<typeof event_function>[1],
+      should_stop: Parameters<typeof event_function>[2],
+      checkpoint: unknown
+    ) =>
+      runWithTriggerCheckpoint(isTriggerCheckpoint(checkpoint) ? checkpoint : undefined, () =>
+        (event_function as (...args: unknown[]) => void)(context, update, should_stop, checkpoint)
+      ),
+  } as TQoreAppAction;
+};
+
 export class ActionsCatalogue {
   public readonly apps: TQoreApps = {};
   public readonly existingApps: TQoreExistingApps = {};
@@ -222,7 +262,7 @@ export class ActionsCatalogue {
       }
 
       registerAppFn(app);
-      actions.forEach(registerActionFn);
+      actions.forEach((action) => registerActionFn(withCheckpointSupport(action)));
     });
   }
 

--- a/ts/src/global/helpers/event-triggers.ts
+++ b/ts/src/global/helpers/event-triggers.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_TRIGGER_POLLING_INTERVAL,
   DEFAULT_TRIGGER_SAVED_ITEMS_LIMIT_MAX,
 } from '../constants';
+import { loadTriggerCheckpoint, saveTriggerCheckpoint } from './trigger-checkpoint';
 
 /**
  * Waits for a specified amount of time or until a stopping condition is met, whichever comes first.
@@ -29,123 +30,239 @@ export const delayOrCancel = (ms: number, shouldStop: () => boolean): Promise<vo
     }),
   ]);
 
+/** The checkpoint envelope stored by {@link pollCreatedItemsForTrigger}. */
+interface ICreatedItemsCheckpoint {
+  version: 1;
+  /** the unique values of the items already delivered */
+  delivered: (string | number)[];
+}
+
+/** The checkpoint envelope stored by {@link pollUpdatedItemsForTrigger}. */
+interface IUpdatedItemsCheckpoint {
+  version: 1;
+  /** the last delivered edit time, by unique value */
+  edits: [string | number, number][];
+}
+
+/**
+ * Orders a page of items oldest-first.
+ *
+ * Without an `orderKey` the page is simply reversed, which is the long-standing behavior and assumes the
+ * upstream API returns items newest-first. That assumption cannot be verified here, so a trigger whose
+ * feed carries a usable ordering key should supply one and get an actual guarantee instead.
+ */
+const orderOldestFirst = <ItemType extends Record<string, any>>(
+  items: ItemType[],
+  orderKey?: (item: ItemType) => number | string
+): ItemType[] => {
+  if (!orderKey) {
+    return [...items].reverse();
+  }
+
+  return [...items].sort((left, right) => {
+    const a = orderKey(left);
+    const b = orderKey(right);
+
+    if (a < b) return -1;
+    if (a > b) return 1;
+    return 0;
+  });
+};
+
+/** Drops the least recently added entries once the delivered set outgrows its bound. */
+const pruneDelivered = (delivered: Set<string | number>): Set<string | number> => {
+  if (delivered.size <= DEFAULT_TRIGGER_SAVED_ITEMS_LIMIT_MAX) {
+    return delivered;
+  }
+
+  // JavaScript sets keep insertion order, so the trailing entries are the most recently added
+  return new Set(Array.from(delivered).slice(-DEFAULT_TRIGGER_SAVED_ITEMS_LIMIT_MAX));
+};
+
 /**
  * Polls for newly created items and triggers an update function for each new item.
  *
- * @template ItemType - The type of the items being polled.
+ * ### Delivery guarantees
+ *
+ * - Items are delivered oldest-first (see `orderKey`), and `update` is awaited, so a trigger that does
+ *   asynchronous work per item still delivers its events in order.
+ * - An item is recorded as delivered only after `update` resolves. A failure ends the current cycle
+ *   without recording it, so the item is retried on the next cycle rather than skipped. Delivery is
+ *   therefore at-least-once, never at-most-once.
+ * - A failing cycle does not stop the trigger; only `should_stop()` ends polling.
+ * - When the host provides a durable checkpoint, the set of delivered items survives a reload, so items
+ *   that arrived while the trigger was down are still delivered. Without one, the first poll establishes
+ *   a baseline from whatever the upstream currently returns and those items are never reported.
+ *
  * @param opts - The options for the polling function.
  * @param opts.trigger_name - The name of the trigger.
  * @param opts.uniqueField - The unique field of the item to identify new items.
  * @param opts.getItems - A function that returns a promise resolving to an array of items.
- * @param opts.update - A function that is called with each new item.
+ * @param opts.orderKey - Optional accessor returning an item's position in the feed; when given, items
+ * are sorted ascending by it instead of the page simply being reversed.
+ * @param opts.update - A function that is called with each new item; awaited if it returns a promise.
  * @param opts.should_stop - A function that returns a boolean indicating whether to stop polling.
  *
  * @returns A promise that resolves when the polling stops.
- *
- * @throws Will throw an error if there is an issue during polling.
  */
 export const pollCreatedItemsForTrigger = async <ItemType extends Record<string, any>>(opts: {
   trigger_name: string;
   uniqueField: keyof ItemType;
   getItems: () => Promise<ItemType[]>;
+  orderKey?: (item: ItemType) => number | string;
   updateLastPollTime?: (lastPoll: Date) => void;
-  update: (data: ItemType) => void;
+  update: (data: ItemType) => void | Promise<void>;
   should_stop: () => boolean;
 }) => {
-  const { trigger_name, getItems, update, should_stop, uniqueField, updateLastPollTime } = opts;
+  const { trigger_name, getItems, update, should_stop, uniqueField, orderKey, updateLastPollTime } =
+    opts;
+
+  let delivered = new Set<string | number>();
 
   try {
-    const initialItems = await getItems();
-    let processedItems = new Set(initialItems.map((item) => item[uniqueField]));
+    const restored = loadTriggerCheckpoint<ICreatedItemsCheckpoint>(trigger_name);
 
-    while (!should_stop()) {
+    if (restored?.version === 1 && Array.isArray(restored.delivered)) {
+      // resume where the previous run stopped, so items that arrived while the trigger was down are
+      // still delivered rather than silently treated as already handled
+      delivered = new Set(restored.delivered);
+    } else {
+      // no durable position: establish a baseline so that a first start does not replay the whole feed
+      const initialItems = await getItems();
+      delivered = new Set(initialItems.map((item) => item[uniqueField]));
+    }
+  } catch (error) {
+    Debugger.log(`Error establishing the initial position for trigger: ${trigger_name}`, error);
+  }
+
+  while (!should_stop()) {
+    try {
       const latestItems = await getItems();
-      latestItems.reverse();
 
-      for (const item of latestItems) {
-        if (!processedItems.has(item[uniqueField])) {
-          update(item);
-          processedItems.add(item[uniqueField]);
+      for (const item of orderOldestFirst(latestItems, orderKey)) {
+        if (should_stop()) {
+          break;
         }
+
+        const id = item[uniqueField];
+
+        if (delivered.has(id)) {
+          continue;
+        }
+
+        // awaited so that an asynchronous update still delivers in order, and so that a failure is
+        // caught here rather than surfacing as an unhandled rejection
+        await update(item);
+        delivered.add(id);
+        await saveTriggerCheckpoint(trigger_name, {
+          version: 1,
+          delivered: Array.from(pruneDelivered(delivered)),
+        } satisfies ICreatedItemsCheckpoint);
       }
 
-      if (processedItems.size > DEFAULT_TRIGGER_SAVED_ITEMS_LIMIT_MAX) {
-        processedItems = new Set(
-          Array.from(processedItems).slice(-DEFAULT_TRIGGER_SAVED_ITEMS_LIMIT_MAX)
-        );
-      }
+      delivered = pruneDelivered(delivered);
 
       if (updateLastPollTime) {
         updateLastPollTime(new Date());
       }
-      await delayOrCancel(DEFAULT_TRIGGER_POLLING_INTERVAL, should_stop);
+    } catch (error) {
+      // end this cycle, not the trigger: items that were not delivered are still not recorded as
+      // delivered, so the next cycle retries them
+      Debugger.log(`Error during polling data for trigger: ${trigger_name}`, error);
     }
-  } catch (error) {
-    Debugger.log(`Error during polling data for trigger: ${trigger_name}`, error);
+
+    await delayOrCancel(DEFAULT_TRIGGER_POLLING_INTERVAL, should_stop);
   }
 };
 
 /**
  * Polls updated items for a specified trigger and performs an update action on each updated item.
  *
- * @template ItemType - The type of the items being polled.
- * @param {Object} opts - The options for the polling function.
- * @param {string} opts.trigger_name - The name of the trigger.
- * @param {keyof ItemType} opts.uniqueField - The unique field of the item used to identify it.
- * @param {keyof ItemType} opts.updatedDateField - The field of the item that contains the date of update.
- * @param {() => Promise<ItemType[]>} opts.getItems - A function that retrieves the items to be polled.
- * @param {(data: ItemType) => void} opts.update - A function that performs an update action on an item.
- * @param {() => boolean} opts.should_stop - A function that determines whether the polling should stop.
+ * Carries the same delivery guarantees as {@link pollCreatedItemsForTrigger}; see that function for
+ * details.
  *
- * @returns {Promise<void>} A promise that resolves when the polling stops.
+ * @param opts - The options for the polling function.
+ * @param opts.trigger_name - The name of the trigger.
+ * @param opts.uniqueField - The unique field of the item used to identify it.
+ * @param opts.updatedDateField - The field of the item that contains the date of update.
+ * @param opts.getItems - A function that retrieves the items to be polled.
+ * @param opts.update - A function that performs an update action on an item; awaited if it returns a promise.
+ * @param opts.should_stop - A function that determines whether the polling should stop.
  *
- * @throws Will throw an error if there is an issue during the polling process.
+ * @returns A promise that resolves when the polling stops.
  */
 export const pollUpdatedItemsForTrigger = async <ItemType extends Record<string, any>>(opts: {
   trigger_name: string;
   uniqueField: keyof ItemType;
   updatedDateField: keyof ItemType;
   getItems: () => Promise<ItemType[]>;
-  update: (data: ItemType) => void;
+  update: (data: ItemType) => void | Promise<void>;
   should_stop: () => boolean;
 }) => {
   const { trigger_name, getItems, update, should_stop, uniqueField, updatedDateField } = opts;
 
-  const lastSeenEdits = new Map();
+  let lastSeenEdits = new Map<string | number, number>();
+
+  const getEditTime = (item: ItemType): number => new Date(get(item, updatedDateField)).getTime();
+
+  const pruneEdits = (edits: Map<string | number, number>): Map<string | number, number> => {
+    if (edits.size <= DEFAULT_TRIGGER_SAVED_ITEMS_LIMIT_MAX) {
+      return edits;
+    }
+
+    const sortedEntries = Array.from(edits.entries()).sort((a, b) => a[1] - b[1]);
+
+    return new Map(sortedEntries.slice(-DEFAULT_TRIGGER_SAVED_ITEMS_LIMIT_MAX));
+  };
 
   try {
-    const initialItems = await getItems();
+    const restored = loadTriggerCheckpoint<IUpdatedItemsCheckpoint>(trigger_name);
 
-    for (const item of initialItems) {
-      const initialTime = new Date(get(item, updatedDateField)).getTime();
-      lastSeenEdits.set(item[uniqueField], initialTime);
-    }
+    if (restored?.version === 1 && Array.isArray(restored.edits)) {
+      lastSeenEdits = new Map(restored.edits);
+    } else {
+      const initialItems = await getItems();
 
-    while (!should_stop()) {
-      const latestItems = await getItems();
-      latestItems.reverse();
-
-      for (const item of latestItems) {
-        const previousEditTime = lastSeenEdits.get(item[uniqueField]);
-        const newEditTime = new Date(get(item, updatedDateField)).getTime();
-        if (!previousEditTime || newEditTime > previousEditTime) {
-          update(item);
-          lastSeenEdits.set(item[uniqueField], newEditTime);
-        }
+      for (const item of initialItems) {
+        lastSeenEdits.set(item[uniqueField], getEditTime(item));
       }
-
-      if (lastSeenEdits.size > DEFAULT_TRIGGER_SAVED_ITEMS_LIMIT_MAX) {
-        const sortedEntries = Array.from(lastSeenEdits.entries()).sort((a, b) => a[1] - b[1]);
-        const toKeep = sortedEntries.slice(-DEFAULT_TRIGGER_SAVED_ITEMS_LIMIT_MAX);
-        lastSeenEdits.clear();
-        for (const [id, time] of toKeep) {
-          lastSeenEdits.set(id, time);
-        }
-      }
-
-      await delayOrCancel(DEFAULT_TRIGGER_POLLING_INTERVAL, should_stop);
     }
   } catch (error) {
-    Debugger.log(`Error during polling data for trigger: ${trigger_name}`, error);
+    Debugger.log(`Error establishing the initial position for trigger: ${trigger_name}`, error);
+  }
+
+  while (!should_stop()) {
+    try {
+      const latestItems = await getItems();
+
+      // oldest edit first, so a failure part-way through leaves only newer edits undelivered
+      const ordered = [...latestItems].sort((left, right) => getEditTime(left) - getEditTime(right));
+
+      for (const item of ordered) {
+        if (should_stop()) {
+          break;
+        }
+
+        const previousEditTime = lastSeenEdits.get(item[uniqueField]);
+        const newEditTime = getEditTime(item);
+
+        if (previousEditTime && newEditTime <= previousEditTime) {
+          continue;
+        }
+
+        await update(item);
+        lastSeenEdits.set(item[uniqueField], newEditTime);
+        await saveTriggerCheckpoint(trigger_name, {
+          version: 1,
+          edits: Array.from(pruneEdits(lastSeenEdits).entries()),
+        } satisfies IUpdatedItemsCheckpoint);
+      }
+
+      lastSeenEdits = pruneEdits(lastSeenEdits);
+    } catch (error) {
+      Debugger.log(`Error during polling data for trigger: ${trigger_name}`, error);
+    }
+
+    await delayOrCancel(DEFAULT_TRIGGER_POLLING_INTERVAL, should_stop);
   }
 };

--- a/ts/src/global/helpers/trigger-checkpoint.ts
+++ b/ts/src/global/helpers/trigger-checkpoint.ts
@@ -1,0 +1,119 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { Debugger } from '../../utils/Debugger';
+
+/**
+ * The durable checkpoint API handed to an event function by the Qore side.
+ *
+ * A checkpoint lets a trigger keep its position in an upstream feed across a host reload. Without one, a
+ * restarted trigger has to establish a fresh baseline from whatever the upstream currently returns, which
+ * silently skips everything that arrived while it was not running.
+ */
+export interface ITriggerCheckpoint {
+  /** Returns the state stored by the previous run, or `undefined` if there is none. */
+  get: <T = Record<string, any>>() => T | undefined;
+  /**
+   * Durably stores the replacement state.
+   *
+   * Only store a position **after** the item it covers has been delivered. Storing it first means a
+   * failure loses the item; storing it afterwards means a failure re-delivers it, which is the
+   * at-least-once guarantee the checkpoint exists to provide.
+   */
+  set: (state: Record<string, any>) => Promise<void> | void;
+}
+
+/**
+ * The checkpoint API for the event function running on the current async call stack.
+ *
+ * Qore passes the checkpoint API as the fourth argument to an event function. Rather than requiring every
+ * trigger to declare and thread that argument through to its polling helper, the action registration wraps
+ * each event function and publishes the API here for the duration of the call. `AsyncLocalStorage` keeps it
+ * correct when several event sources run concurrently in one JavaScript program: each invocation gets its
+ * own store, and the store follows the call across `await` boundaries.
+ */
+const checkpointStorage = new AsyncLocalStorage<ITriggerCheckpoint>();
+
+/**
+ * Runs an event function with the given checkpoint API published for the duration of the call.
+ *
+ * @param checkpoint - the checkpoint API supplied by the Qore side, if any.
+ * @param fn - the event function invocation to run.
+ */
+export const runWithTriggerCheckpoint = <T>(
+  checkpoint: ITriggerCheckpoint | undefined,
+  fn: () => T
+): T => {
+  if (!checkpoint) {
+    return fn();
+  }
+
+  return checkpointStorage.run(checkpoint, fn);
+};
+
+/**
+ * Returns the checkpoint API for the running event function, if the host provides one.
+ *
+ * Returns `undefined` when no host checkpoint callback is configured, in which case a trigger keeps
+ * in-memory state only and re-baselines on restart.
+ */
+export const getTriggerCheckpoint = (): ITriggerCheckpoint | undefined => checkpointStorage.getStore();
+
+/**
+ * Returns `true` if the given value looks like a checkpoint API.
+ *
+ * The value crosses the Qore/JavaScript boundary, so it is validated rather than trusted.
+ */
+export const isTriggerCheckpoint = (value: unknown): value is ITriggerCheckpoint =>
+  !!value &&
+  typeof (value as ITriggerCheckpoint).get === 'function' &&
+  typeof (value as ITriggerCheckpoint).set === 'function';
+
+/**
+ * Stores a checkpoint without letting a storage failure interrupt event delivery.
+ *
+ * A checkpoint that is not stored costs re-delivery of already-delivered items after a restart, never a
+ * lost item, so a failure here is logged and polling continues.
+ *
+ * @param trigger_name - the trigger name, for diagnostics.
+ * @param state - the state to store.
+ */
+export const saveTriggerCheckpoint = async (
+  trigger_name: string,
+  state: Record<string, any>
+): Promise<void> => {
+  const checkpoint = getTriggerCheckpoint();
+
+  if (!checkpoint) {
+    return;
+  }
+
+  try {
+    await checkpoint.set(state);
+  } catch (error) {
+    Debugger.log(
+      `Could not store the delivery checkpoint for trigger: ${trigger_name}; items already delivered may be delivered again after a restart`,
+      error
+    );
+  }
+};
+
+/**
+ * Returns the state stored by the previous run of the current trigger, if any.
+ *
+ * @param trigger_name - the trigger name, for diagnostics.
+ */
+export const loadTriggerCheckpoint = <T = Record<string, any>>(
+  trigger_name: string
+): T | undefined => {
+  const checkpoint = getTriggerCheckpoint();
+
+  if (!checkpoint) {
+    return undefined;
+  }
+
+  try {
+    return checkpoint.get<T>();
+  } catch (error) {
+    Debugger.log(`Could not read the delivery checkpoint for trigger: ${trigger_name}`, error);
+    return undefined;
+  }
+};

--- a/ts/src/global/helpers/trigger-checkpoint.ts
+++ b/ts/src/global/helpers/trigger-checkpoint.ts
@@ -9,8 +9,13 @@ import { Debugger } from '../../utils/Debugger';
  * silently skips everything that arrived while it was not running.
  */
 export interface ITriggerCheckpoint {
-  /** Returns the state stored by the previous run, or `undefined` if there is none. */
-  get: <T = Record<string, any>>() => T | undefined;
+  /**
+   * Returns the state stored by the previous run, or `undefined` if there is none.
+   *
+   * The shape is whatever the trigger stored, so this is deliberately untyped here: the caller knows the
+   * shape it wrote and validates it, which {@link loadTriggerCheckpoint} exposes as its type parameter.
+   */
+  get: () => Record<string, any> | undefined;
   /**
    * Durably stores the replacement state.
    *
@@ -99,6 +104,9 @@ export const saveTriggerCheckpoint = async (
 /**
  * Returns the state stored by the previous run of the current trigger, if any.
  *
+ * The stored state crosses a restart and the host's storage, so `T` states what the caller wrote rather
+ * than what was read back; callers validate the value before trusting it.
+ *
  * @param trigger_name - the trigger name, for diagnostics.
  */
 export const loadTriggerCheckpoint = <T = Record<string, any>>(
@@ -111,7 +119,7 @@ export const loadTriggerCheckpoint = <T = Record<string, any>>(
   }
 
   try {
-    return checkpoint.get<T>();
+    return checkpoint.get() as T | undefined;
   } catch (error) {
     Debugger.log(`Could not read the delivery checkpoint for trigger: ${trigger_name}`, error);
     return undefined;

--- a/ts/src/i18n/en/apps/Outlook/index.ts
+++ b/ts/src/i18n/en/apps/Outlook/index.ts
@@ -699,9 +699,9 @@ const OutlookAppEn = {
         },
         action: {
           displayName: 'Email Action',
-          shortDesc: 'Action to perform after triggering',
+          shortDesc: 'Action to perform once the email event has been raised',
           longDesc:
-            'Optional action to perform on emails after the trigger runs. Choose "None" to leave emails unchanged, "Delete" to remove the email, or "Move" to relocate the email to another folder.',
+            'Optional action to perform on each email once its event has been raised. Choose "None" to leave emails unchanged, "Delete" to remove the email, or "Move" to relocate the email to another folder.\n\nThe action runs as soon as the event has been **raised**, which is not the same as the consumer having **processed** it: a consumer that receives the event and then fails, times out, or is restarted mid-processing has already lost the email, and a delete cannot be undone. For any workload that must not lose the source email, leave this set to "None" and act from the consumer once processing has succeeded, using the message ID the event carries.',
         },
         targetFolderId: {
           displayName: 'Target Folder',

--- a/ts/src/tests/event-triggers.test.ts
+++ b/ts/src/tests/event-triggers.test.ts
@@ -1,0 +1,387 @@
+import {
+  pollCreatedItemsForTrigger,
+  pollUpdatedItemsForTrigger,
+} from '../global/helpers/event-triggers';
+import {
+  ITriggerCheckpoint,
+  runWithTriggerCheckpoint,
+} from '../global/helpers/trigger-checkpoint';
+
+jest.mock('../global/constants', () => ({
+  ...jest.requireActual('../global/constants'),
+  // keep the tests fast: the real interval is 10 minutes
+  DEFAULT_TRIGGER_POLLING_INTERVAL: 5,
+}));
+
+interface ITestItem extends Record<string, any> {
+  id: string;
+  created: number;
+  updated?: string;
+}
+
+/** A checkpoint API backed by memory, standing in for the host's durable storage. */
+const makeCheckpoint = (
+  initial?: Record<string, any>
+): ITriggerCheckpoint & { saved: Record<string, any>[]; state?: Record<string, any> } => {
+  const cp: any = {
+    state: initial,
+    saved: [] as Record<string, any>[],
+    get: () => cp.state,
+    set: async (state: Record<string, any>) => {
+      cp.state = state;
+      cp.saved.push(state);
+    },
+  };
+
+  return cp;
+};
+
+describe('pollCreatedItemsForTrigger', () => {
+  it('delivers items oldest-first from a newest-first page', async () => {
+    const delivered: string[] = [];
+    let polls = 0;
+
+    await pollCreatedItemsForTrigger<ITestItem>({
+      trigger_name: 'test',
+      uniqueField: 'id',
+      // newest first, as a "latest N" API returns
+      getItems: async () => {
+        polls++;
+        return [
+          { id: 'c', created: 30 },
+          { id: 'b', created: 20 },
+          { id: 'a', created: 10 },
+        ];
+      },
+      update: (item) => {
+        delivered.push(item.id);
+      },
+      should_stop: () => polls > 1,
+    });
+
+    // the first getItems() establishes the baseline, so nothing is delivered without a checkpoint
+    expect(delivered).toEqual([]);
+  });
+
+  it('delivers new items oldest-first once a baseline exists', async () => {
+    const delivered: string[] = [];
+    let polls = 0;
+    let page: ITestItem[] = [{ id: 'a', created: 10 }];
+
+    await pollCreatedItemsForTrigger<ITestItem>({
+      trigger_name: 'test',
+      uniqueField: 'id',
+      getItems: async () => {
+        // the baseline sees only 'a'; two newer items appear afterwards, newest first
+        const result = page;
+        polls++;
+        page = [
+          { id: 'c', created: 30 },
+          { id: 'b', created: 20 },
+          { id: 'a', created: 10 },
+        ];
+        return result;
+      },
+      update: (item) => {
+        delivered.push(item.id);
+      },
+      should_stop: () => polls > 2,
+    });
+
+    expect(delivered).toEqual(['b', 'c']);
+  });
+
+  it('sorts by an explicit ordering key rather than assuming newest-first', async () => {
+    const delivered: string[] = [];
+    let polls = 0;
+
+    await pollCreatedItemsForTrigger<ITestItem>({
+      trigger_name: 'test',
+      uniqueField: 'id',
+      orderKey: (item) => item.created,
+      // deliberately unordered: reversing this page would not produce ascending order
+      getItems: async () =>
+        polls++ === 0
+          ? []
+          : [
+              { id: 'b', created: 20 },
+              { id: 'c', created: 30 },
+              { id: 'a', created: 10 },
+            ],
+      update: (item) => {
+        delivered.push(item.id);
+      },
+      should_stop: () => polls > 2,
+    });
+
+    expect(delivered).toEqual(['a', 'b', 'c']);
+  });
+
+  it('awaits an asynchronous update so events keep their order', async () => {
+    const delivered: string[] = [];
+    let polls = 0;
+    const delays: Record<string, number> = { a: 30, b: 10, c: 1 };
+
+    await pollCreatedItemsForTrigger<ITestItem>({
+      trigger_name: 'test',
+      uniqueField: 'id',
+      getItems: async () =>
+        polls++ === 0
+          ? []
+          : [
+              { id: 'c', created: 30 },
+              { id: 'b', created: 20 },
+              { id: 'a', created: 10 },
+            ],
+      // the slowest item is the oldest: without awaiting, it would be delivered last
+      update: async (item) => {
+        await new Promise((resolve) => setTimeout(resolve, delays[item.id]));
+        delivered.push(item.id);
+      },
+      should_stop: () => polls > 2,
+    });
+
+    expect(delivered).toEqual(['a', 'b', 'c']);
+  });
+
+  it('keeps polling after an item fails, and retries that item', async () => {
+    const delivered: string[] = [];
+    let polls = 0;
+    let failed = false;
+
+    await pollCreatedItemsForTrigger<ITestItem>({
+      trigger_name: 'test',
+      uniqueField: 'id',
+      getItems: async () =>
+        polls++ === 0
+          ? []
+          : [
+              { id: 'b', created: 20 },
+              { id: 'a', created: 10 },
+            ],
+      update: (item) => {
+        if (item.id === 'a' && !failed) {
+          failed = true;
+          throw new Error('transient delivery failure');
+        }
+        delivered.push(item.id);
+      },
+      should_stop: () => polls > 4,
+    });
+
+    // the failure ended its cycle without recording 'a' as delivered, and polling continued, so both
+    // items are delivered in order on a later cycle
+    expect(failed).toBe(true);
+    expect(delivered).toEqual(['a', 'b']);
+  });
+
+  it('keeps polling after getItems() fails', async () => {
+    const delivered: string[] = [];
+    let polls = 0;
+    let threw = false;
+
+    await pollCreatedItemsForTrigger<ITestItem>({
+      trigger_name: 'test',
+      uniqueField: 'id',
+      getItems: async () => {
+        const cycle = polls++;
+        if (cycle === 1 && !threw) {
+          threw = true;
+          throw new Error('upstream unavailable');
+        }
+        return cycle === 0 ? [] : [{ id: 'a', created: 10 }];
+      },
+      update: (item) => {
+        delivered.push(item.id);
+      },
+      should_stop: () => polls > 4,
+    });
+
+    expect(threw).toBe(true);
+    expect(delivered).toEqual(['a']);
+  });
+
+  it('resumes from a durable checkpoint instead of re-baselining', async () => {
+    const delivered: string[] = [];
+    let polls = 0;
+    const checkpoint = makeCheckpoint({ version: 1, delivered: ['a'] });
+
+    await runWithTriggerCheckpoint(checkpoint, () =>
+      pollCreatedItemsForTrigger<ITestItem>({
+        trigger_name: 'test',
+        uniqueField: 'id',
+        // 'b' arrived while the trigger was down; without the checkpoint it would be baselined away
+        getItems: async () => {
+          polls++;
+          return [
+            { id: 'b', created: 20 },
+            { id: 'a', created: 10 },
+          ];
+        },
+        update: (item) => {
+          delivered.push(item.id);
+        },
+        should_stop: () => polls > 1,
+      })
+    );
+
+    expect(delivered).toEqual(['b']);
+    expect(checkpoint.saved.at(-1)).toEqual({ version: 1, delivered: ['a', 'b'] });
+  });
+
+  it('stores a checkpoint only after the item has been delivered', async () => {
+    const order: string[] = [];
+    let polls = 0;
+    const checkpoint = makeCheckpoint({ version: 1, delivered: [] });
+
+    await runWithTriggerCheckpoint(checkpoint, () =>
+      pollCreatedItemsForTrigger<ITestItem>({
+        trigger_name: 'test',
+        uniqueField: 'id',
+        getItems: async () => {
+          polls++;
+          return [{ id: 'a', created: 10 }];
+        },
+        update: () => {
+          order.push('delivered');
+        },
+        should_stop: () => polls > 1,
+      })
+    );
+
+    const saveIndex = order.push('end') - 1;
+
+    expect(order[0]).toBe('delivered');
+    expect(saveIndex).toBe(1);
+    expect(checkpoint.saved).toHaveLength(1);
+  });
+
+  it('does not store a checkpoint for an item whose delivery failed', async () => {
+    let polls = 0;
+    const checkpoint = makeCheckpoint({ version: 1, delivered: [] });
+
+    await runWithTriggerCheckpoint(checkpoint, () =>
+      pollCreatedItemsForTrigger<ITestItem>({
+        trigger_name: 'test',
+        uniqueField: 'id',
+        getItems: async () => {
+          polls++;
+          return [{ id: 'a', created: 10 }];
+        },
+        update: () => {
+          throw new Error('delivery failed');
+        },
+        should_stop: () => polls > 1,
+      })
+    );
+
+    expect(checkpoint.saved).toHaveLength(0);
+    expect(checkpoint.state).toEqual({ version: 1, delivered: [] });
+  });
+
+  it('survives a checkpoint storage failure without stopping delivery', async () => {
+    const delivered: string[] = [];
+    let polls = 0;
+    const checkpoint: ITriggerCheckpoint = {
+      get: () => ({ version: 1, delivered: [] }),
+      set: async () => {
+        throw new Error('checkpoint storage unavailable');
+      },
+    };
+
+    await runWithTriggerCheckpoint(checkpoint, () =>
+      pollCreatedItemsForTrigger<ITestItem>({
+        trigger_name: 'test',
+        uniqueField: 'id',
+        getItems: async () => {
+          polls++;
+          return [
+            { id: 'b', created: 20 },
+            { id: 'a', created: 10 },
+          ];
+        },
+        update: (item) => {
+          delivered.push(item.id);
+        },
+        should_stop: () => polls > 1,
+      })
+    );
+
+    // a checkpoint that cannot be stored costs re-delivery after a restart, never a lost item
+    expect(delivered).toEqual(['a', 'b']);
+  });
+
+  it('works unchanged when the host provides no checkpoint', async () => {
+    const delivered: string[] = [];
+    let polls = 0;
+
+    await pollCreatedItemsForTrigger<ITestItem>({
+      trigger_name: 'test',
+      uniqueField: 'id',
+      getItems: async () => (polls++ === 0 ? [] : [{ id: 'a', created: 10 }]),
+      update: (item) => {
+        delivered.push(item.id);
+      },
+      should_stop: () => polls > 2,
+    });
+
+    expect(delivered).toEqual(['a']);
+  });
+});
+
+describe('pollUpdatedItemsForTrigger', () => {
+  it('delivers edits oldest-first and resumes from a checkpoint', async () => {
+    const delivered: string[] = [];
+    let polls = 0;
+    const checkpoint = makeCheckpoint({ version: 1, edits: [['a', 1000]] });
+
+    await runWithTriggerCheckpoint(checkpoint, () =>
+      pollUpdatedItemsForTrigger<ITestItem>({
+        trigger_name: 'test',
+        uniqueField: 'id',
+        updatedDateField: 'updated',
+        getItems: async () => {
+          polls++;
+          return [
+            { id: 'c', created: 0, updated: new Date(3000).toISOString() },
+            { id: 'a', created: 0, updated: new Date(2000).toISOString() },
+            { id: 'b', created: 0, updated: new Date(1500).toISOString() },
+          ];
+        },
+        update: (item) => {
+          delivered.push(item.id);
+        },
+        should_stop: () => polls > 1,
+      })
+    );
+
+    // 'a' was last seen at 1000 and has since been edited, so it is delivered again; ordering is by
+    // edit time, so the oldest edit comes first
+    expect(delivered).toEqual(['b', 'a', 'c']);
+  });
+
+  it('keeps polling after an update fails', async () => {
+    const delivered: string[] = [];
+    let polls = 0;
+    let failed = false;
+
+    await pollUpdatedItemsForTrigger<ITestItem>({
+      trigger_name: 'test',
+      uniqueField: 'id',
+      updatedDateField: 'updated',
+      getItems: async () =>
+        polls++ === 0 ? [] : [{ id: 'a', created: 0, updated: new Date(2000).toISOString() }],
+      update: (item) => {
+        if (!failed) {
+          failed = true;
+          throw new Error('transient failure');
+        }
+        delivered.push(item.id);
+      },
+      should_stop: () => polls > 4,
+    });
+
+    expect(failed).toBe(true);
+    expect(delivered).toEqual(['a']);
+  });
+});

--- a/ts/src/tests/event-triggers.test.ts
+++ b/ts/src/tests/event-triggers.test.ts
@@ -2,7 +2,9 @@ import {
   pollCreatedItemsForTrigger,
   pollUpdatedItemsForTrigger,
 } from '../global/helpers/event-triggers';
+import { withCheckpointSupport } from '../ActionsCatalogue';
 import {
+  getTriggerCheckpoint,
   ITriggerCheckpoint,
   runWithTriggerCheckpoint,
 } from '../global/helpers/trigger-checkpoint';
@@ -19,15 +21,23 @@ interface ITestItem extends Record<string, any> {
   updated?: string;
 }
 
-/** A checkpoint API backed by memory, standing in for the host's durable storage. */
+/**
+ * A checkpoint API backed by memory, standing in for the host's durable storage.
+ *
+ * @param initial - the state a previous run left behind, if any.
+ * @param trace - optional log that records when a store happens, so a test can assert the order of
+ * delivery against storage rather than only that both occurred.
+ */
 const makeCheckpoint = (
-  initial?: Record<string, any>
+  initial?: Record<string, any>,
+  trace?: string[]
 ): ITriggerCheckpoint & { saved: Record<string, any>[]; state?: Record<string, any> } => {
   const cp: any = {
     state: initial,
     saved: [] as Record<string, any>[],
     get: () => cp.state,
     set: async (state: Record<string, any>) => {
+      trace?.push('stored');
       cp.state = state;
       cp.saved.push(state);
     },
@@ -230,9 +240,11 @@ describe('pollCreatedItemsForTrigger', () => {
   });
 
   it('stores a checkpoint only after the item has been delivered', async () => {
+    // both the delivery and the store append here, so the assertion sees their real relative order:
+    // storing a position first would mean a failure loses the item it covers
     const order: string[] = [];
     let polls = 0;
-    const checkpoint = makeCheckpoint({ version: 1, delivered: [] });
+    const checkpoint = makeCheckpoint({ version: 1, delivered: [] }, order);
 
     await runWithTriggerCheckpoint(checkpoint, () =>
       pollCreatedItemsForTrigger<ITestItem>({
@@ -240,20 +252,21 @@ describe('pollCreatedItemsForTrigger', () => {
         uniqueField: 'id',
         getItems: async () => {
           polls++;
-          return [{ id: 'a', created: 10 }];
+          return [
+            { id: 'a', created: 10 },
+            { id: 'b', created: 20 },
+          ];
         },
-        update: () => {
-          order.push('delivered');
+        update: (item) => {
+          order.push(`delivered:${item.id}`);
         },
         should_stop: () => polls > 1,
       })
     );
 
-    const saveIndex = order.push('end') - 1;
-
-    expect(order[0]).toBe('delivered');
-    expect(saveIndex).toBe(1);
-    expect(checkpoint.saved).toHaveLength(1);
+    // note the page is reversed, so 'b' is delivered first
+    expect(order).toEqual(['delivered:b', 'stored', 'delivered:a', 'stored']);
+    expect(checkpoint.saved).toHaveLength(2);
   });
 
   it('does not store a checkpoint for an item whose delivery failed', async () => {
@@ -383,5 +396,85 @@ describe('pollUpdatedItemsForTrigger', () => {
 
     expect(failed).toBe(true);
     expect(delivered).toEqual(['a']);
+  });
+});
+
+describe('withCheckpointSupport', () => {
+  const makeAction = (event_function: any): any => ({
+    app: 'test',
+    action: 'test',
+    action_code: 1,
+    event_function,
+  });
+
+  it('propagates the return value of an async event function', async () => {
+    // the Qore side awaits the returned promise; discarding it would let the host treat the event
+    // function as already finished and would swallow a rejection
+    let finished = false;
+    const wrapped: any = withCheckpointSupport(
+      makeAction(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        finished = true;
+        return 'result';
+      })
+    );
+
+    const returned = wrapped.event_function({}, () => {}, () => false, undefined);
+
+    expect(returned).toBeInstanceOf(Promise);
+    expect(finished).toBe(false);
+    await expect(returned).resolves.toBe('result');
+    expect(finished).toBe(true);
+  });
+
+  it('propagates a rejection rather than swallowing it', async () => {
+    const wrapped: any = withCheckpointSupport(
+      makeAction(async () => {
+        throw new Error('event function failed');
+      })
+    );
+
+    await expect(
+      wrapped.event_function({}, () => {}, () => false, undefined)
+    ).rejects.toThrow('event function failed');
+  });
+
+  it('publishes the checkpoint to the event function and anything it calls', async () => {
+    const checkpoint = makeCheckpoint({ version: 1, delivered: ['x'] });
+    let seenInside: any;
+    let seenAfterAwait: any;
+
+    const wrapped: any = withCheckpointSupport(
+      makeAction(async () => {
+        seenInside = getTriggerCheckpoint();
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        // the store must still resolve after an await, since a poller reads it deep in its own stack
+        seenAfterAwait = getTriggerCheckpoint();
+      })
+    );
+
+    await wrapped.event_function({}, () => {}, () => false, checkpoint);
+
+    expect(seenInside).toBe(checkpoint);
+    expect(seenAfterAwait).toBe(checkpoint);
+  });
+
+  it('leaves an action without an event function untouched', () => {
+    const action: any = { app: 'test', action: 'test', action_code: 0 };
+
+    expect(withCheckpointSupport(action)).toBe(action);
+  });
+
+  it('ignores a fourth argument that is not a checkpoint API', async () => {
+    let seen: any = 'unset';
+    const wrapped: any = withCheckpointSupport(
+      makeAction(async () => {
+        seen = getTriggerCheckpoint();
+      })
+    );
+
+    await wrapped.event_function({}, () => {}, () => false, { bogus: true });
+
+    expect(seen).toBeUndefined();
   });
 });

--- a/ts/src/tests/event-triggers.test.ts
+++ b/ts/src/tests/event-triggers.test.ts
@@ -21,6 +21,12 @@ interface ITestItem extends Record<string, any> {
   updated?: string;
 }
 
+/** A checkpoint API that also exposes what it stored, so a test can assert on it. */
+type TTestCheckpoint = ITriggerCheckpoint & {
+  saved: Record<string, any>[];
+  state?: Record<string, any>;
+};
+
 /**
  * A checkpoint API backed by memory, standing in for the host's durable storage.
  *
@@ -31,10 +37,10 @@ interface ITestItem extends Record<string, any> {
 const makeCheckpoint = (
   initial?: Record<string, any>,
   trace?: string[]
-): ITriggerCheckpoint & { saved: Record<string, any>[]; state?: Record<string, any> } => {
-  const cp: any = {
+): TTestCheckpoint => {
+  const cp: TTestCheckpoint = {
     state: initial,
-    saved: [] as Record<string, any>[],
+    saved: [],
     get: () => cp.state,
     set: async (state: Record<string, any>) => {
       trace?.push('stored');


### PR DESCRIPTION
Follow-on to the watch-provider work in qore#5380 (#5377 / #5378), applying the same delivery contract to the TypeScript trigger side.

## The problem

All 225 polling triggers in `ts/src/apps` route through `pollCreatedItemsForTrigger` / `pollUpdatedItemsForTrigger`. Those helpers had the same class of defects the Qore-side watch providers had, plus one that was worse:

| | Before |
|---|---|
| **Durable cursor** | None, and unreachable. `processedItems` was an in-memory `Set` seeded from an initial `getItems()` whose results were all marked already-seen — so a restart silently skipped everything that arrived while the trigger was down. `TypeScriptActionEventDataProvider` inherited `DelayedObservable`, not the watch base, so there was no checkpoint contract to hook into. |
| **Failure containment** | The `try` wrapped the entire `while` loop. One throw from `getItems()` or `update()` ended polling **permanently** — a single transient error killed the trigger until the event source was restarted. |
| **Ordering** | `update(item)` was never awaited. Four triggers pass an `async` callback, so their events interleaved out of order despite the `reverse()`, and rejections were unhandled. |
| **Advance on success** | An item was recorded as delivered before its async work completed. |
| **Removal semantics** | Outlook's `action: delete\|move` fires right after `update()`; the option text said only *"delete the email permanently or move it to another folder"*. |

## What this does

**Qore side.** `TypeScriptActionEventDataProvider` now also inherits `AbstractWatchDataProviderBase`. The event function owns its own loop, so that base's polling machinery is unused — what it provides is the durable checkpoint contract. The provider hands the event function a checkpoint API as a fourth argument:

```js
event_function: async (ctx, update, should_stop, checkpoint) => {
    let state = checkpoint.get();               // stored by the previous run
    update(item);
    await checkpoint.set({ cursor: item.id });  // durable once this returns
}
```

State is opaque to the provider and wrapped in a versioned envelope with a monotonic sequence number, so a checkpoint arriving out of order cannot move the cursor backwards. Both execution paths carry it: the in-process thread passes the API directly; the external process receives the restored state with `SETUP-EVENT` and pushes replacements back over the event socket via the new `EVENT-CHECKPOINT` command. A restarted child resumes from the position the previous child reached, not the one restored at startup.

**TypeScript side.** The checkpoint is published through `AsyncLocalStorage` at the single point where actions are registered, so **all 225 polling triggers get durable cursors without being touched**. `AsyncLocalStorage` gives each event-function invocation its own store and follows it across `await`, so concurrent event sources in one JS program don't collide. (Verified it works and propagates in the embedded V8, not just Node.)

**Poller fixes, independent of checkpoints:**
- a failure ends the *cycle*, not the trigger; the next cycle retries
- `update()` is awaited — ordered delivery, and rejections are caught
- an item is recorded delivered only after `update()` resolves
- optional `orderKey` sorts by a real ordering key instead of assuming newest-first

**Docs.** The Outlook option now states the action runs when the event has been *raised*, which is not the same as the consumer having *processed* it.

## Tests

- `ts/src/tests/event-triggers.test.ts` — 13 new cases: ordering from a newest-first page, explicit `orderKey`, awaited async updates (slowest item is the oldest, so it fails without the await), failure containment for both `getItems()` and `update()`, checkpoint restore instead of re-baselining, store-only-after-delivery, no store on failure, and survival of a checkpoint storage failure.
- `test/ts-action-interface.qtest` — 2 new cases driving the real Qore/JavaScript boundary in both directions: restored state reaching `checkpoint.get()`, stored state reaching the host callback with its envelope, a resumed provider advancing from the restored position, and rejection of malformed envelopes.

14/14 qtest cases pass (against installed qmods) and the 21 non-credential-gated TypeScript suites pass. The 39 failing suites are pre-existing live-API integration tests that need credentials (`Please set the X environment variable`); none are in code touched here.

## Follow-up (not in this PR)

`ts-toolkit`'s `IQoreAppActionWithEvent.event_function` type could gain an optional fourth `checkpoint` parameter so a trigger can declare it directly. Not required — the `AsyncLocalStorage` route means no trigger needs the parameter — and the local toolkit checkout is 26 commits behind its remote, so it isn't a safe base to branch from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)